### PR TITLE
Hybrid esn input layer

### DIFF
--- a/src/ReservoirComputing.jl
+++ b/src/ReservoirComputing.jl
@@ -22,8 +22,8 @@ export ESNtrain, Ridge, Lasso, ElastNet, RobustHuber
 include("nla.jl")
 export nla, NLADefault, NLAT1, NLAT2, NLAT3
 
-include("esn_input_layers.jl") 
-export init_input_layer, init_dense_input_layer, init_sparse_input_layer, min_complex_input, irrational_sign_input
+include("esn_input_layers.jl")
+export init_input_layer, init_dense_input_layer, init_sparse_input_layer, min_complex_input, irrational_sign_input, physics_informed_input
 include("esn_reservoirs.jl")
 export init_reservoir_givendeg, init_reservoir_givensp, pseudoSVD, DLR, DLRB, SCR, CRJ
 

--- a/src/esn_input_layers.jl
+++ b/src/esn_input_layers.jl
@@ -118,3 +118,22 @@ function irrational_sign_input(res_size::Int,
     end
     return W_in
 end
+
+"""
+physics_informed_input(res_size::Int, in_size::Int, sigma::Float64, γ::Float64)
+
+Return a weighted input layer matrix, with random non-zero elements drawn from \$ [-\\text{sigma}, \\text{sigma}] \$, where some γ
+of reservoir nodes are connected exclusively to the raw inputs, and the rest to the outputs of the prior knowledge model , as described in [1].
+
+[1] Jaideep Pathak et al. "Hybrid Forecasting of Chaotic Processes: Using Machine Learning in Conjunction with a Knowledge-Based Model" (2018)
+"""
+function physics_informed_input(res_size::Int,
+        in_size::Int,
+        sigma::Float64,
+        γ::Float64,
+        model_in_size::Int)
+
+    W_in = zeros(Float64, res_size, in_size)
+
+    return W_in
+end

--- a/src/esn_input_layers.jl
+++ b/src/esn_input_layers.jl
@@ -133,7 +133,26 @@ function physics_informed_input(res_size::Int,
         γ::Float64,
         model_in_size::Int)
 
+    state_size = in_size - model_in_size
     W_in = zeros(Float64, res_size, in_size)
+    #Num of res nodes available for raw states
+    num_for_state = floor(Int, res_size*γ)
+    #Num of res nodes available for prior model input
+    num_for_model = floor(Int, (res_size*(1-γ)))
+    #Num of nodes per raw state input
+    q_state = floor(Int, num_for_state/state_size)
+    #Num of nodes per prior model input
+    q_model = floor(Int, num_for_model/model_in_size)
+    start_idx = 1
+    for i in 1:in_size
 
+        if i <= in_size-model_in_size
+            W_in[start_idx:start_idx-1+q_state, i] = (2*sigma).*(rand(Float64, 1, q_state).-0.5)
+            start_idx = start_idx+q_state
+        else
+            W_in[start_idx:start_idx-1+q_model, i] = (2*sigma).*(rand(Float64, 1, q_model).-0.5)
+            start_idx = start_idx+q_model
+        end
+    end
     return W_in
 end

--- a/src/esn_input_layers.jl
+++ b/src/esn_input_layers.jl
@@ -143,14 +143,14 @@ function physics_informed_input(res_size::Int,
     num_for_model = floor(Int, (res_size*(1-γ)))
     for i in 1:num_for_state
         #find res nodes with no connections
-        idxs = findall(Bool[zero_connections[1:state_size] == W_in[i,1:state_size] for i=1:size(W_in,1)])
+        idxs = findall(Bool[zero_connections == W_in[i,:] for i=1:size(W_in,1)])
         random_row_idx = idxs[rand(1:end)]
         random_clm_idx = range(1, state_size, step = 1)[rand(1:end)]
         W_in[random_row_idx,random_clm_idx] = rand(Uniform(-sigma, sigma))
     end
 
     for i in 1:num_for_model
-        idxs = findall(Bool[zero_connections[1:model_in_size] == W_in[i,state_size+1:end] for i=1:size(W_in,1)])
+        idxs = findall(Bool[zero_connections == W_in[i,:] for i=1:size(W_in,1)])
         random_row_idx = idxs[rand(1:end)]
         random_clm_idx = range(state_size+1, in_size, step = 1)[rand(1:end)]
         W_in[random_row_idx,random_clm_idx] = rand(Uniform(-sigma, sigma))

--- a/test/fixed_layers/test_esn_input_layers.jl
+++ b/test/fixed_layers/test_esn_input_layers.jl
@@ -59,4 +59,4 @@ W_in = physics_informed_input(res_size, in_size, sigma, γ, model_in_size)
 #Test num weights have been alotted correctly for model input according to the gamma chosen
 @test sum(x->x!=0, W_in[:, 3]) == floor(Int, res_size*(1-γ))
 #Test every reservoir node is connected exclusively to one state
-@test sum(x->x=1, [sum(x->x!=0, W_in[i, :]) for i in 1:res_size]) == res_size
+@test length(findall(x->x>1, [sum(x->x!=0, W_in[i, :]) for i in 1:res_size])) == 0

--- a/test/fixed_layers/test_esn_input_layers.jl
+++ b/test/fixed_layers/test_esn_input_layers.jl
@@ -60,3 +60,6 @@ W_in = physics_informed_input(res_size, in_size, sigma, γ, model_in_size)
 @test sum(x->x!=0, W_in[:, 3]) == floor(Int, res_size*(1-γ))
 #Test every reservoir node is connected exclusively to one state
 @test length(findall(x->x>1, [sum(x->x!=0, W_in[i, :]) for i in 1:res_size])) == 0
+#Test in_size to always be greater than model output size
+bad_model_out_size = 10
+@test_throws DimensionMismatch physics_informed_input(res_size, in_size, sigma, γ, bad_model_out_size)

--- a/test/fixed_layers/test_esn_input_layers.jl
+++ b/test/fixed_layers/test_esn_input_layers.jl
@@ -50,3 +50,16 @@ for t in input_layer
     @test size(W_in, 1) == res_size
     @test size(W_in, 2) == in_size
 end
+
+
+#test physics informed input layer function
+W_in = physics_informed_input(res_size, in_size, sigma, γ, model_in_size)
+
+#Test num weights have been alotted correctly for state 1 according to the gamma chosen
+@test sum(x->x!=0, W_in[:, 1]) == floor(Int, (res_size*γ)/(in_size - model_in_size))
+#Test num weights have been alotted correctly for state 2 according to the gamma chosen
+@test sum(x->x!=0, W_in[:, 2]) == floor(Int, (res_size*γ)/(in_size - model_in_size))
+#Test num weights have been alotted correctly for model input 1 according to the gamma chosen
+@test sum(x->x!=0, W_in[:, 3]) == floor(Int, (res_size*(1-γ))/(model_in_size))
+#Test every reservoir node is connected exclusively to one state
+@test sum(x->x=1, [sum(x->x!=0, W_in[i, :]) for i in 1:res_size]) == res_size

--- a/test/fixed_layers/test_esn_input_layers.jl
+++ b/test/fixed_layers/test_esn_input_layers.jl
@@ -54,12 +54,9 @@ end
 
 #test physics informed input layer function
 W_in = physics_informed_input(res_size, in_size, sigma, γ, model_in_size)
-
-#Test num weights have been alotted correctly for state 1 according to the gamma chosen
-@test sum(x->x!=0, W_in[:, 1]) == floor(Int, (res_size*γ)/(in_size - model_in_size))
-#Test num weights have been alotted correctly for state 2 according to the gamma chosen
-@test sum(x->x!=0, W_in[:, 2]) == floor(Int, (res_size*γ)/(in_size - model_in_size))
-#Test num weights have been alotted correctly for model input 1 according to the gamma chosen
-@test sum(x->x!=0, W_in[:, 3]) == floor(Int, (res_size*(1-γ))/(model_in_size))
+#Test num weights have been alotted correctly for raw states according to the gamma chosen
+@test sum(x->x!=0, W_in[:, 1:2]) == floor(Int, res_size*γ)
+#Test num weights have been alotted correctly for model input according to the gamma chosen
+@test sum(x->x!=0, W_in[:, 3]) == floor(Int, res_size*(1-γ))
 #Test every reservoir node is connected exclusively to one state
 @test sum(x->x=1, [sum(x->x!=0, W_in[i, :]) for i in 1:res_size]) == res_size

--- a/test/fixed_layers/test_esn_input_layers.jl
+++ b/test/fixed_layers/test_esn_input_layers.jl
@@ -13,6 +13,9 @@ nla_type = NLADefault()
 in_size = 3
 extended_states = false
 h_steps = 2
+#Let gamma be any number between 0 and 1
+γ = rand()
+model_in_size = 1
 
 W = init_reservoir_givendeg(res_size, radius, degree)
 
@@ -23,12 +26,16 @@ train = data[:, 1:1+train_len-1]
 test = data[:, train_len:train_len+predict_len-1]
 
 #test input layers functions
-input_layer = [init_input_layer, init_dense_input_layer, init_sparse_input_layer, min_complex_input, irrational_sign_input]
+input_layer = [init_input_layer, init_dense_input_layer, init_sparse_input_layer, min_complex_input, irrational_sign_input, physics_informed_input]
 
 for t in input_layer
 
     if t == init_sparse_input_layer
         W_in = t(res_size, in_size, sigma, sparsity)
+
+    elseif t == physics_informed_input
+        W_in = t(res_size, in_size, sigma, γ, model_in_size)
+
     else
         W_in = t(res_size, in_size, sigma)
     end
@@ -38,7 +45,7 @@ for t in input_layer
         activation = activation,
         alpha = alpha,
         nla_type = nla_type,
-        extended_states = extended_states) 
+        extended_states = extended_states)
 
     @test size(W_in, 1) == res_size
     @test size(W_in, 2) == in_size


### PR DESCRIPTION
This is implementation of the input layer for the hybrid echo state network. It is assumed that the vector of inputs is such that the raw states are followed by the inputs of the model in order. The user specifies what the expected number of inputs are for the model, and some gamma for what percent of  the connections are made between the raw inputs and the reservoir nodes exclusively, while the rest are connected to the reservoir nodes and model inputs. No one reservoir node is connected to more than once. What remains is to allow the prior knowledge to be specified as an argument into an ESN model, and do the same for the output layer as what was done for the input layer