### PR TITLE
HESN-Constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReservoirComputing"
 uuid = "7c2d2b1e-3dd4-11ea-355a-8f6a8116e294"
 authors = ["Francesco Martinuzzi"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/src/ReservoirComputing.jl
+++ b/src/ReservoirComputing.jl
@@ -22,8 +22,8 @@ export ESNtrain, Ridge, Lasso, ElastNet, RobustHuber
 include("nla.jl")
 export nla, NLADefault, NLAT1, NLAT2, NLAT3
 
-include("esn_input_layers.jl") 
-export init_input_layer, init_dense_input_layer, init_sparse_input_layer, min_complex_input, irrational_sign_input
+include("esn_input_layers.jl")
+export init_input_layer, init_dense_input_layer, init_sparse_input_layer, min_complex_input, irrational_sign_input, physics_informed_input
 include("esn_reservoirs.jl")
 export init_reservoir_givendeg, init_reservoir_givensp, pseudoSVD, DLR, DLRB, SCR, CRJ
 

--- a/src/ReservoirComputing.jl
+++ b/src/ReservoirComputing.jl
@@ -56,4 +56,7 @@ export RMM, RMMdirect_predict
 include("gruesn.jl")
 export GRUESN, GRUESNpredict
 
+include("hesn.jl")
+export HESN
+
 end #module

--- a/src/esn_input_layers.jl
+++ b/src/esn_input_layers.jl
@@ -118,3 +118,22 @@ function irrational_sign_input(res_size::Int,
     end
     return W_in
 end
+
+"""
+physics_informed_input(res_size::Int, in_size::Int, sigma::Float64, γ::Float64)
+
+Return a weighted input layer matrix, with random non-zero elements drawn from \$ [-\\text{sigma}, \\text{sigma}] \$, where some γ
+of reservoir nodes are connected exclusively to the raw inputs, and the rest to the outputs of the prior knowledge model , as described in [1].
+
+[1] Jaideep Pathak et al. "Hybrid Forecasting of Chaotic Processes: Using Machine Learning in Conjunction with a Knowledge-Based Model" (2018)
+"""
+function physics_informed_input(res_size::Int,
+        in_size::Int,
+        sigma::Float64,
+        γ::Float64,
+        model_in_size::Int)
+
+    W_in = zeros(Float64, res_size, in_size)
+
+    return W_in
+end

--- a/src/esn_input_layers.jl
+++ b/src/esn_input_layers.jl
@@ -133,7 +133,26 @@ function physics_informed_input(res_size::Int,
         γ::Float64,
         model_in_size::Int)
 
+    state_size = in_size - model_in_size
     W_in = zeros(Float64, res_size, in_size)
+    #Num of res nodes available for raw states
+    num_for_state = floor(Int, res_size*γ)
+    #Num of res nodes available for prior model input
+    num_for_model = floor(Int, (res_size*(1-γ)))
+    #Num of nodes per raw state input
+    q_state = floor(Int, num_for_state/state_size)
+    #Num of nodes per prior model input
+    q_model = floor(Int, num_for_model/model_in_size)
+    start_idx = 1
+    for i in 1:in_size
 
+        if i <= in_size-model_in_size
+            W_in[start_idx:start_idx-1+q_state, i] = (2*sigma).*(rand(Float64, 1, q_state).-0.5)
+            start_idx = start_idx+q_state
+        else
+            W_in[start_idx:start_idx-1+q_model, i] = (2*sigma).*(rand(Float64, 1, q_model).-0.5)
+            start_idx = start_idx+q_model
+        end
+    end
     return W_in
 end

--- a/src/esn_input_layers.jl
+++ b/src/esn_input_layers.jl
@@ -143,14 +143,14 @@ function physics_informed_input(res_size::Int,
     num_for_model = floor(Int, (res_size*(1-γ)))
     for i in 1:num_for_state
         #find res nodes with no connections
-        idxs = findall(Bool[zero_connections[1:state_size] == W_in[i,1:state_size] for i=1:size(W_in,1)])
+        idxs = findall(Bool[zero_connections == W_in[i,:] for i=1:size(W_in,1)])
         random_row_idx = idxs[rand(1:end)]
         random_clm_idx = range(1, state_size, step = 1)[rand(1:end)]
         W_in[random_row_idx,random_clm_idx] = rand(Uniform(-sigma, sigma))
     end
 
     for i in 1:num_for_model
-        idxs = findall(Bool[zero_connections[1:model_in_size] == W_in[i,state_size+1:end] for i=1:size(W_in,1)])
+        idxs = findall(Bool[zero_connections == W_in[i,:] for i=1:size(W_in,1)])
         random_row_idx = idxs[rand(1:end)]
         random_clm_idx = range(state_size+1, in_size, step = 1)[rand(1:end)]
         W_in[random_row_idx,random_clm_idx] = rand(Uniform(-sigma, sigma))

--- a/src/esn_input_layers.jl
+++ b/src/esn_input_layers.jl
@@ -134,6 +134,9 @@ function physics_informed_input(res_size::Int,
         model_in_size::Int)
 
     state_size = in_size - model_in_size
+    if state_size <= 0
+        throw(DimensionMismatch("in_size must be greater than model_in_size"))
+    end
     W_in = zeros(Float64, res_size, in_size)
     #Vector used to find res nodes not yet connected
     zero_connections = zeros(in_size)

--- a/src/hesn.jl
+++ b/src/hesn.jl
@@ -28,8 +28,8 @@ function HESN(W::AbstractArray{T},
         extended_states::Bool = false) where T<:AbstractFloat
 
     physics_data = prior_model(u0, tspan, datasize)
-    train_data = vcat(train_data, physics_data)
-    in_size = size(train_data, 1)
+    physics_informed_data = vcat(train_data, physics_data)
+    in_size = size(physics_informed_data, 1)
     out_size = size(train_data, 1)
     res_size = size(W, 1)
 
@@ -39,7 +39,7 @@ function HESN(W::AbstractArray{T},
         throw(DimensionMismatch("size(W_in, 2) must be equal to in_size"))
     end
 
-    states = states_matrix(W, W_in, train_data, alpha, activation, extended_states)
+    states = states_matrix(W, W_in, physics_informed_data, alpha, activation, extended_states)
 
     return HESN{T, typeof(train_data),
         typeof(res_size),

--- a/src/hesn.jl
+++ b/src/hesn.jl
@@ -1,12 +1,16 @@
 abstract type AbstractHESN <: AbstractEchoStateNetwork end
 
-struct HESN{T, S<:AbstractArray{T}, I, B, F, N, M} <: AbstractHESN
+struct HESN{T, S<:AbstractArray{T}, I, B, F, N, M, U} <: AbstractHESN
     res_size::I
     in_size::I
     out_size::I
     train_data::S
     physics_model_data::S
     prior_model::M
+    u0::U
+    tspan::Tuple
+    datasize::I
+    dt::T
     alpha::T
     nla_type::N
     activation::F
@@ -30,10 +34,10 @@ function HESN(W::AbstractArray{T},
 
     #Create physics data with one extra step ahead extra
     trange = collect(range(tspan[1], tspan[2], length = datasize))
-    dt = tspan[2]-trange[1]
+    dt = trange[2]-trange[1]
     tsteps = push!(trange, dt + trange[end])
-    tspan = (tspan[1], dt+tspan[2])
-    physics_model_data = prior_model(u0, tspan, tsteps)
+    tspan_new = (tspan[1], dt+tspan[2])
+    physics_model_data = prior_model(u0, tspan_new, tsteps)
     physics_informed_data = vcat(train_data, physics_model_data[:, 1:end-1])
 
     in_size = size(physics_informed_data, 1)
@@ -53,6 +57,7 @@ function HESN(W::AbstractArray{T},
         typeof(extended_states),
         typeof(activation),
         typeof(nla_type),
-        typeof(prior_model)}(res_size, in_size, out_size, train_data, physics_model_data,
-        prior_model, alpha, nla_type, activation, W, W_in, states, extended_states)
+        typeof(prior_model),
+        typeof(u0)}(res_size, in_size, out_size, train_data, physics_model_data,
+        prior_model, u0, tspan, datasize, dt, alpha, nla_type, activation, W, W_in, states, extended_states)
 end

--- a/src/hesn.jl
+++ b/src/hesn.jl
@@ -1,0 +1,51 @@
+abstract type AbstractHESN <: AbstractEchoStateNetwork end
+
+struct HESN{T, S<:AbstractArray{T}, I, B, F, N, M} <: AbstractHESN
+    res_size::I
+    in_size::I
+    out_size::I
+    train_data::S
+    prior_model::M
+    alpha::T
+    nla_type::N
+    activation::F
+    W::S
+    W_in::S
+    states::S
+    extended_states::B
+end
+
+function HESN(W::AbstractArray{T},
+        train_data::AbstractArray{T},
+        prior_model::Any,
+        u0::AbstractArray{T},
+        tspan::Tuple,
+        datasize::Int,
+        W_in::AbstractArray{T};
+        activation::Any = tanh,
+        alpha::T = 1.0,
+        nla_type::NonLinearAlgorithm = NLADefault(),
+        extended_states::Bool = false) where T<:AbstractFloat
+
+    physics_data = prior_model(u0, tspan, datasize)
+    train_data = vcat(train_data, physics_data)
+    in_size = size(train_data, 1)
+    out_size = size(train_data, 1)
+    res_size = size(W, 1)
+
+    if size(W_in, 1) != res_size
+        throw(DimensionMismatch("size(W_in, 1) must be equal to size(W, 1)"))
+    elseif size(W_in, 2) != in_size
+        throw(DimensionMismatch("size(W_in, 2) must be equal to in_size"))
+    end
+
+    states = states_matrix(W, W_in, train_data, alpha, activation, extended_states)
+
+    return HESN{T, typeof(train_data),
+        typeof(res_size),
+        typeof(extended_states),
+        typeof(activation),
+        typeof(nla_type),
+        typeof(prior_model)}(res_size, in_size, out_size, train_data, prior_model,
+    alpha, nla_type, activation, W, W_in, states, extended_states)
+end

--- a/test/constructors/test_hesn_constructors.jl
+++ b/test/constructors/test_hesn_constructors.jl
@@ -39,7 +39,6 @@ function prior_model(u0, tspan, datasize, model = lorenz)
     sol = ones(length(u0), length(tsteps))
     return sol
 end
-concat_train = vcat(train, prior_model(u0, tspan, datasize))
 #constructor 1
 hesn = HESN(W,
     train,
@@ -56,7 +55,7 @@ hesn = HESN(W,
 
 #test constructor
 @test isequal(Integer(floor(approx_res_size/in_size)*in_size), hesn.res_size)
-@test isequal(concat_train, hesn.train_data)
+@test isequal(train, hesn.train_data)
 @test isequal(alpha, hesn.alpha)
 @test isequal(activation, hesn.activation)
 @test isequal(nla_type, hesn.nla_type)

--- a/test/constructors/test_hesn_constructors.jl
+++ b/test/constructors/test_hesn_constructors.jl
@@ -26,7 +26,7 @@ const h_steps = 2
 const train_len = 50
 const predict_len = 12
 data = ones(Float64, in_size-out_size, 100).+γ
-train = data[:, 1:1+train_len-1]
+train = data[:, 1:train_len]
 
 #test = data[:, train_len:train_len+predict_len-1]
 
@@ -60,6 +60,7 @@ hesn = HESN(W,
     nla_type = nla_type,
     extended_states = extended_states)
 
+
 #test constructor
 @test isequal(Integer(floor(approx_res_size/in_size)*in_size), hesn.res_size)
 @test isequal(train, hesn.train_data)
@@ -76,3 +77,13 @@ hesn = HESN(W,
 @test size(hesn.W) == (hesn.res_size, hesn.res_size)
 @test size(hesn.W_in) == (hesn.res_size, hesn.in_size)
 @test size(hesn.states) == (hesn.res_size, train_len)
+
+
+#test dimension mismatch of hesn constructor
+bad_in_size = 4
+W_in = ReservoirComputing.physics_informed_input(approx_res_size, bad_in_size, sigma, γ, prior_model_size)
+@test_throws DimensionMismatch hesn2 = HESN(W, train, prior_model, u0, tspan, datasize, W_in, activation = activation, alpha = alpha, nla_type = nla_type, extended_states = extended_states)
+
+bad_res_size = approx_res_size-1
+W_in = ReservoirComputing.physics_informed_input(bad_res_size, in_size, sigma, γ, prior_model_size)
+@test_throws DimensionMismatch hesn2 = HESN(W, train, prior_model, u0, tspan, datasize, W_in, activation = activation, alpha = alpha, nla_type = nla_type, extended_states = extended_states)

--- a/test/constructors/test_hesn_constructors.jl
+++ b/test/constructors/test_hesn_constructors.jl
@@ -28,8 +28,6 @@ const predict_len = 12
 data = ones(Float64, in_size-out_size, 100).+γ
 train = data[:, 1:train_len]
 
-#test = data[:, train_len:train_len+predict_len-1]
-
 
 #user physics function
 function lorenz()
@@ -60,10 +58,7 @@ hesn = HESN(W,
     nla_type = nla_type,
     extended_states = extended_states)
 
-<<<<<<< HEAD
 
-=======
->>>>>>> HESN-Constructor
 #test constructor
 @test isequal(Integer(floor(approx_res_size/in_size)*in_size), hesn.res_size)
 @test isequal(train, hesn.train_data)
@@ -80,7 +75,7 @@ hesn = HESN(W,
 @test size(hesn.W) == (hesn.res_size, hesn.res_size)
 @test size(hesn.W_in) == (hesn.res_size, hesn.in_size)
 @test size(hesn.states) == (hesn.res_size, train_len)
-<<<<<<< HEAD
+
 
 
 #test dimension mismatch of hesn constructor
@@ -91,5 +86,3 @@ W_in = ReservoirComputing.physics_informed_input(approx_res_size, bad_in_size, s
 bad_res_size = approx_res_size-1
 W_in = ReservoirComputing.physics_informed_input(bad_res_size, in_size, sigma, γ, prior_model_size)
 @test_throws DimensionMismatch hesn2 = HESN(W, train, prior_model, u0, tspan, datasize, W_in, activation = activation, alpha = alpha, nla_type = nla_type, extended_states = extended_states)
-=======
->>>>>>> HESN-Constructor

--- a/test/constructors/test_hesn_constructors.jl
+++ b/test/constructors/test_hesn_constructors.jl
@@ -37,15 +37,15 @@ end
 
 #physics data generator for training and prediction
 trange = collect(range(tspan[1], tspan[2], length = train_len))
-dt = tspan[2]-trange[1]
+dt = trange[2]-trange[1]
 tsteps = push!(trange, dt + trange[end])
-tspan1 = (tspan[1], dt+tspan[2])
+tspan_new = (tspan[1], dt+tspan[2])
 
-function prior_model(u0, tspan1, tsteps, model = lorenz)
+function prior_model(u0, tspan_new, tsteps, model = lorenz)
     sol = ones(length(u0), length(tsteps)).*γ
     return sol
 end
-physics_model_data = prior_model(u0, tspan1, tsteps)
+physics_model_data = prior_model(u0, tspan_new, tsteps)
 
 #constructor 1
 hesn = HESN(W,
@@ -63,12 +63,16 @@ hesn = HESN(W,
 #test constructor
 @test isequal(Integer(floor(approx_res_size/in_size)*in_size), hesn.res_size)
 @test isequal(train, hesn.train_data)
-@test isequal(prior_model(u0, tspan1, tsteps), hesn.physics_model_data)
+@test isequal(prior_model(u0, tspan_new, tsteps), hesn.physics_model_data)
 @test isequal(vcat(train, physics_model_data[:, 1:end-1]), vcat(hesn.train_data, hesn.physics_model_data[:,1:end-1]))
 @test isequal(alpha, hesn.alpha)
 @test isequal(activation, hesn.activation)
 @test isequal(nla_type, hesn.nla_type)
 @test isequal(prior_model, hesn.prior_model)
+@test isequal(datasize, hesn.datasize)
+@test isequal(u0, hesn.u0)
+@test isequal(tspan, hesn.tspan)
+@test isequal(dt, hesn.dt)
 @test size(hesn.W) == (hesn.res_size, hesn.res_size)
 @test size(hesn.W_in) == (hesn.res_size, hesn.in_size)
 @test size(hesn.states) == (hesn.res_size, train_len)

--- a/test/constructors/test_hesn_constructors.jl
+++ b/test/constructors/test_hesn_constructors.jl
@@ -1,0 +1,66 @@
+using ReservoirComputing
+
+#model parameters
+const approx_res_size = 30
+const radius = 1.2
+const activation = tanh
+const degree = 6
+const sigma = 0.1
+const beta = 0.0
+const alpha = 1.0
+const nla_type = NLADefault()
+const in_size = 6
+const out_size = 3
+const γ = rand()
+const prior_model_size = 3
+const u0 = [1.0,0.0,0.0]
+const tspan = (0.0,1000.0)
+const datasize = 50
+W_in = ReservoirComputing.physics_informed_input(approx_res_size, in_size, sigma, γ, prior_model_size)
+W = ReservoirComputing.init_reservoir_givendeg(approx_res_size, radius, degree)
+const extended_states = false
+const h_steps = 2
+
+
+const train_len = 50
+const predict_len = 12
+data = ones(Float64, in_size-out_size, 100)
+train = data[:, 1:1+train_len-1]
+#test = data[:, train_len:train_len+predict_len-1]
+
+
+#user physics function
+function lorenz()
+end
+
+#physics data generator for training and prediction
+function prior_model(u0, tspan, datasize, model = lorenz)
+    tsteps = range(tspan[1], tspan[2], length = datasize)
+    sol = ones(length(u0), length(tsteps))
+    return sol
+end
+concat_train = vcat(train, prior_model(u0, tspan, datasize))
+#constructor 1
+hesn = HESN(W,
+    train,
+    prior_model,
+    u0,
+    tspan,
+    datasize,
+    W_in,
+    activation = activation,
+    alpha = alpha,
+    nla_type = nla_type,
+    extended_states = extended_states)
+
+
+#test constructor
+@test isequal(Integer(floor(approx_res_size/in_size)*in_size), hesn.res_size)
+@test isequal(concat_train, hesn.train_data)
+@test isequal(alpha, hesn.alpha)
+@test isequal(activation, hesn.activation)
+@test isequal(nla_type, hesn.nla_type)
+@test isequal(prior_model, hesn.prior_model)
+@test size(hesn.W) == (hesn.res_size, hesn.res_size)
+@test size(hesn.W_in) == (hesn.res_size, hesn.in_size)
+@test size(hesn.states) == (hesn.res_size, train_len)

--- a/test/fixed_layers/test_esn_input_layers.jl
+++ b/test/fixed_layers/test_esn_input_layers.jl
@@ -59,4 +59,4 @@ W_in = physics_informed_input(res_size, in_size, sigma, γ, model_in_size)
 #Test num weights have been alotted correctly for model input according to the gamma chosen
 @test sum(x->x!=0, W_in[:, 3]) == floor(Int, res_size*(1-γ))
 #Test every reservoir node is connected exclusively to one state
-@test sum(x->x=1, [sum(x->x!=0, W_in[i, :]) for i in 1:res_size]) == res_size
+@test length(findall(x->x>1, [sum(x->x!=0, W_in[i, :]) for i in 1:res_size])) == 0

--- a/test/fixed_layers/test_esn_input_layers.jl
+++ b/test/fixed_layers/test_esn_input_layers.jl
@@ -60,3 +60,6 @@ W_in = physics_informed_input(res_size, in_size, sigma, γ, model_in_size)
 @test sum(x->x!=0, W_in[:, 3]) == floor(Int, res_size*(1-γ))
 #Test every reservoir node is connected exclusively to one state
 @test length(findall(x->x>1, [sum(x->x!=0, W_in[i, :]) for i in 1:res_size])) == 0
+#Test in_size to always be greater than model output size
+bad_model_out_size = 10
+@test_throws DimensionMismatch physics_informed_input(res_size, in_size, sigma, γ, bad_model_out_size)

--- a/test/fixed_layers/test_esn_input_layers.jl
+++ b/test/fixed_layers/test_esn_input_layers.jl
@@ -50,3 +50,16 @@ for t in input_layer
     @test size(W_in, 1) == res_size
     @test size(W_in, 2) == in_size
 end
+
+
+#test physics informed input layer function
+W_in = physics_informed_input(res_size, in_size, sigma, γ, model_in_size)
+
+#Test num weights have been alotted correctly for state 1 according to the gamma chosen
+@test sum(x->x!=0, W_in[:, 1]) == floor(Int, (res_size*γ)/(in_size - model_in_size))
+#Test num weights have been alotted correctly for state 2 according to the gamma chosen
+@test sum(x->x!=0, W_in[:, 2]) == floor(Int, (res_size*γ)/(in_size - model_in_size))
+#Test num weights have been alotted correctly for model input 1 according to the gamma chosen
+@test sum(x->x!=0, W_in[:, 3]) == floor(Int, (res_size*(1-γ))/(model_in_size))
+#Test every reservoir node is connected exclusively to one state
+@test sum(x->x=1, [sum(x->x!=0, W_in[i, :]) for i in 1:res_size]) == res_size

--- a/test/fixed_layers/test_esn_input_layers.jl
+++ b/test/fixed_layers/test_esn_input_layers.jl
@@ -54,12 +54,9 @@ end
 
 #test physics informed input layer function
 W_in = physics_informed_input(res_size, in_size, sigma, γ, model_in_size)
-
-#Test num weights have been alotted correctly for state 1 according to the gamma chosen
-@test sum(x->x!=0, W_in[:, 1]) == floor(Int, (res_size*γ)/(in_size - model_in_size))
-#Test num weights have been alotted correctly for state 2 according to the gamma chosen
-@test sum(x->x!=0, W_in[:, 2]) == floor(Int, (res_size*γ)/(in_size - model_in_size))
-#Test num weights have been alotted correctly for model input 1 according to the gamma chosen
-@test sum(x->x!=0, W_in[:, 3]) == floor(Int, (res_size*(1-γ))/(model_in_size))
+#Test num weights have been alotted correctly for raw states according to the gamma chosen
+@test sum(x->x!=0, W_in[:, 1:2]) == floor(Int, res_size*γ)
+#Test num weights have been alotted correctly for model input according to the gamma chosen
+@test sum(x->x!=0, W_in[:, 3]) == floor(Int, res_size*(1-γ))
 #Test every reservoir node is connected exclusively to one state
 @test sum(x->x=1, [sum(x->x!=0, W_in[i, :]) for i in 1:res_size]) == res_size

--- a/test/fixed_layers/test_esn_input_layers.jl
+++ b/test/fixed_layers/test_esn_input_layers.jl
@@ -13,6 +13,9 @@ nla_type = NLADefault()
 in_size = 3
 extended_states = false
 h_steps = 2
+#Let gamma be any number between 0 and 1
+γ = rand()
+model_in_size = 1
 
 W = init_reservoir_givendeg(res_size, radius, degree)
 
@@ -23,12 +26,16 @@ train = data[:, 1:1+train_len-1]
 test = data[:, train_len:train_len+predict_len-1]
 
 #test input layers functions
-input_layer = [init_input_layer, init_dense_input_layer, init_sparse_input_layer, min_complex_input, irrational_sign_input]
+input_layer = [init_input_layer, init_dense_input_layer, init_sparse_input_layer, min_complex_input, irrational_sign_input, physics_informed_input]
 
 for t in input_layer
 
     if t == init_sparse_input_layer
         W_in = t(res_size, in_size, sigma, sparsity)
+
+    elseif t == physics_informed_input
+        W_in = t(res_size, in_size, sigma, γ, model_in_size)
+
     else
         W_in = t(res_size, in_size, sigma)
     end
@@ -38,7 +45,7 @@ for t in input_layer
         activation = activation,
         alpha = alpha,
         nla_type = nla_type,
-        extended_states = extended_states) 
+        extended_states = extended_states)
 
     @test size(W_in, 1) == res_size
     @test size(W_in, 2) == in_size

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using SafeTestsets
 
 
 @time @safetestset "ESN constructors" begin include("constructors/test_esn_constructors.jl") end
+@time @safetestset "HESN constructors" begin include("constructors/test_hesn_constructors.jl") end
 @time @safetestset "DAFESN constructors" begin include("constructors/test_dafesn_constructors.jl") end
 @time @safetestset "ESN input layers" begin include("fixed_layers/test_esn_input_layers.jl") end
 @time @safetestset "ESN reservoirs" begin include("fixed_layers/test_esn_reservoirs.jl") end


### PR DESCRIPTION
Here's my implementation of the constructor for the HESN. One of the fields is a prior model function that generates data from a provided model of the form written below as well as the u0, tspan and tsteps to saveat. Wanted to make it so that any kind of differential equation can be accepted and generated given the user configures prior_model_data_generator to his problem:

```julia
function lorenz(du,u,p,t)
    p = [10.0,28.0,8/3]
    du[1] = p[1]*(u[2]-u[1])
    du[2] = u[1]*(p[2]-u[3]) - u[2]
    du[3] = u[1]*u[2] - p[3]*u[3]
end

function prior_model_data_generator(u0, tspan, tsteps, model = lorenz)
    prob = ODEProblem(lorenz, u0, tspan) 
    sol = Array(solve(prob, saveat = tsteps))
    return sol
end

```
The rest of the added fields i.e physics_model_data, u0, tspan, and datasize are used for training and prediction.

For training, my understanding is that the output of the HESN uses a one step ahead prediction value from the prior model relative to the value used for the input, so I made the model solve for one extra time step inside the HESN function:

```julia
    trange = collect(range(tspan[1], tspan[2], length = datasize))
    dt = trange[2]-trange[1]
    tsteps = push!(trange, dt + trange[end])
    tspan_new = (tspan[1], dt+tspan[2])
    physics_model_data = prior_model(u0, tspan_new, tsteps)
    physics_informed_data = vcat(train_data, physics_model_data[:, 1:end-1])
    states = states_matrix(W, W_in, physics_informed_data, alpha, activation, extended_states)
```

This way, when we generate the initial reservoir states, we can use the physics model data in the input at the current time step, and when we train the physics model data we use physics_model_data[:, 2:end] - which is one step ahead. Does this make sense? @ChrisRackauckas @MartinuzziFrancesco 

I have posted my idea of the training function here so you can see how this implementation connects with it

```julia
HESNtrain(ridge::Ridge{T}, hesn::AbstractReservoirComputer; train_data::AbstractArray{Float64} = hesn.train_data) where T<: AbstractFloat = _PIridge(hesn, ridge; train_data = hesn.train_data)

function _PIridge(hesn::AbstractReservoirComputer, ridge::Ridge; train_data::AbstractArray{Float64} = hesn.train_data)

    states_new = nla(hesn.nla_type, hesn.states)
    states_new = vcat(states_new, hesn.physics_model_data[:, 2:end])
    W_out = zeros(Float64, size(train_data, 1), size(states_new, 1))
    for i=1:size(train_data, 1)
        r = RidgeRegression(lambda = ridge.lambda, fit_intercept = false)
        W_out[i,:] = MLJLinearModels.fit(r, states_new', train_data[i,:], solver = ridge.solver)
    end

    return W_out
end
```

Going to pr the training function after the first 2 pieces feel coherent to you guys and make sense (physics input layer and this constructor