### PR TITLE
Fix nla allocation situation

### DIFF
--- a/src/states.jl
+++ b/src/states.jl
@@ -93,6 +93,12 @@ function nla(::NLADefault, x)
     return x
 end
 
+function nla(nla_type, x_old)
+    x_new = similar(x_old)
+    nla!(nla_type, x_old, x_new)
+    return x_new
+end
+
 """
     NLAT1()
 Applies the \$ \\text{T}_1 \$ transformation algorithm, as defined in [1] and [2].
@@ -107,15 +113,9 @@ Physical review letters 120.2 (2018): 024102.
 """
 struct NLAT1 <: NonLinearAlgorithm end
 
-function nla(::NLAT1, x_old)
-    x_new = copy(x_old)
-    for i in 1:size(x_new, 1)
-        if mod(i, 2)!=0
-            x_new[i,:] = copy(x_old[i,:].*x_old[i,:])
-        end
-    end
-
-    return x_new
+function nla!(::NLAT1, x_old, x_new)
+    x_new[2:2:end, :] = x_old[2:2:end, :]
+    x_new[1:2:end, :] = x_old[1:2:end, :].^2
 end
 
 """
@@ -128,15 +128,10 @@ and RNN-LSTM._" (2019).
 """
 struct NLAT2 <: NonLinearAlgorithm end
 
-function nla(::NLAT2, x_old)
-    x_new = copy(x_old)
-    for i in 2:size(x_new, 1)-1
-        if mod(i, 2)!=0
-            x_new[i,:] = copy(x_old[i-1,:].*x_old[i-2,:])
-        end
-    end
-
-    return x_new
+function nla!(::NLAT2, x_old, x_new)
+    x_new[1, :] = x_old[1, :]
+    x_new[2:2:end, :] = x_old[2:2:end, :]
+    x_new[3:2:end-1, :] = x_old[2:2:end-2, :].*x_old[1:2:end-3, :]
 end
 
 """
@@ -149,13 +144,8 @@ and RNN-LSTM._" (2019).
 """
 struct NLAT3 <: NonLinearAlgorithm end
 
-function nla(::NLAT3, x_old)
-    x_new = copy(x_old)
-    for i in 2:size(x_new, 1)-1
-        if mod(i, 2)!=0
-            x_new[i,:] = copy(x_old[i-1,:].*x_old[i+1,:])
-        end
-    end
-
-    return x_new
+function nla!(::NLAT3, x_old, x_new)
+    x_new[1,:]= x_old[1, :]
+    x_new[2:2:end, :]= x_old[2:2:end, :]
+    x_new[3:2:end-1, :]= x_old[2:2:end-2, :].*x_old[4:2:end, :]
 end

--- a/src/states.jl
+++ b/src/states.jl
@@ -93,7 +93,13 @@ function nla(::NLADefault, x)
     return x
 end
 
-function nla(nla_type, x_old)
+struct NLAT1 <: NonLinearAlgorithm end
+
+struct NLAT2 <: NonLinearAlgorithm end
+
+struct NLAT3 <: NonLinearAlgorithm end
+
+function nla(nla_type::Union{NLAT1, NLAT2, NLAT3}, x_old)
     x_new = similar(x_old)
     nla!(nla_type, x_old, x_new)
     return x_new
@@ -111,7 +117,6 @@ ANN, and RNN-LSTM._" (2019).
 systems from data: A reservoir computing approach._"
 Physical review letters 120.2 (2018): 024102.
 """
-struct NLAT1 <: NonLinearAlgorithm end
 
 function nla!(::NLAT1, x_old, x_new)
     x_new[2:2:end, :] = x_old[2:2:end, :]
@@ -126,10 +131,12 @@ Apply the \$ \\text{T}_2 \$ transformation algorithm, as defined in [1].
 chaotic system using a hierarchy of deep learning methods: Reservoir computing, ANN,
 and RNN-LSTM._" (2019).
 """
-struct NLAT2 <: NonLinearAlgorithm end
 
 function nla!(::NLAT2, x_old, x_new)
     x_new[1, :] = x_old[1, :]
+    if mod(size(x_new, 1), 2) != 0
+        x_new[end, :] = x_old[end, :]
+    end
     x_new[2:2:end, :] = x_old[2:2:end, :]
     x_new[3:2:end-1, :] = x_old[2:2:end-2, :].*x_old[1:2:end-3, :]
 end
@@ -142,10 +149,12 @@ Apply the \$ \\text{T}_3 \$ transformation algorithm, as defined in [1].
 chaotic system using a hierarchy of deep learning methods: Reservoir computing, ANN,
 and RNN-LSTM._" (2019).
 """
-struct NLAT3 <: NonLinearAlgorithm end
 
 function nla!(::NLAT3, x_old, x_new)
-    x_new[1,:]= x_old[1, :]
+    x_new[1, :] = x_old[1, :]
+    if mod(size(x_new, 1), 2) != 0
+        x_new[end, :] = x_old[end, :]
+    end
     x_new[2:2:end, :]= x_old[2:2:end, :]
     x_new[3:2:end-1, :]= x_old[2:2:end-2, :].*x_old[4:2:end, :]
 end


### PR DESCRIPTION
This is an attempt at fixing #120. Preemptive apologies if the code isn't up to best practices, I just saw the issue lying around and tried to hack together a solution.

I'm on Julia 1.7.3, so there are some tests failing ( #124 ), but the _same_ tests fail before and after, so at least we have that going.

The speedups are most noticeable for the case of many calls with small arrays, with ~1.2-1.4x speedup for 1k x 1k arrays. I don't know what the arrays are supposed to look like, so I just tested out a bunch of sizes.

I'm not really a common Julia package contributor, so I can attempt edits if there's something I've done horrendously wrong in terms of style/best practices.