### PR TITLE
feat: add block_diagonal initializer

### DIFF
--- a/docs/src/api/inits.md
+++ b/docs/src/api/inits.md
@@ -3,46 +3,47 @@
 ## Input layers
 
 ```@docs
+    chebyshev_mapping
+    informed_init
+    logistic_mapping
+    minimal_init
+    modified_lm
     scaled_rand
     weighted_init
-    minimal_init
     weighted_minimal
-    chebyshev_mapping
-    logistic_mapping
-    modified_lm
-    informed_init
 ```
 
 ## Reservoirs
 
 ```@docs
-    rand_sparse
-    pseudo_svd
+    block_diagonal
     chaotic_init
-    low_connectivity
+    cycle_jumps
     delay_line
     delay_line_backward
-    simple_cycle
-    cycle_jumps
     double_cycle
-    true_double_cycle
-    selfloop_cycle
-    selfloop_feedback_cycle
-    selfloop_delayline_backward
-    selfloop_forward_connection
     forward_connection
+    low_connectivity
+    pseudo_svd
+    rand_sparse
+    selfloop_cycle
+    selfloop_delayline_backward
+    selfloop_feedback_cycle
+    selfloop_forward_connection
+    simple_cycle
+    true_double_cycle
 ```
 
 ## Building functions
 
 ```@docs
-    scale_radius!
-    delay_line!
-    backward_connection!
-    simple_cycle!
-    reverse_simple_cycle!
-    self_loop!
     add_jumps!
+    backward_connection!
+    delay_line!
+    reverse_simple_cycle!
+    scale_radius!
+    self_loop!
+    simple_cycle!
 ```
 
 ## References

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -327,3 +327,17 @@
   year = {2020},
   month = dec 
 }
+
+@article{Ma2023,
+  title = {Efficient forecasting of chaotic systems with block-diagonal and binary reservoir computing},
+  volume = {33},
+  ISSN = {1089-7682},
+  url = {http://dx.doi.org/10.1063/5.0151290},
+  DOI = {10.1063/5.0151290},
+  number = {6},
+  journal = {Chaos: An Interdisciplinary Journal of Nonlinear Science},
+  publisher = {AIP Publishing},
+  author = {Ma,  Haochun and Prosperino,  Davide and Haluszczynski,  Alexander and R\"{a}th,  Christoph},
+  year = {2023},
+  month = jun 
+}

--- a/src/ReservoirComputing.jl
+++ b/src/ReservoirComputing.jl
@@ -37,15 +37,14 @@ include("reca/reca_input_encodings.jl")
 export NLADefault, NLAT1, NLAT2, NLAT3, PartialSquare, ExtendedSquare
 export StandardStates, ExtendedStates, PaddedStates, PaddedExtendedStates
 export StandardRidge
-export scaled_rand, weighted_init, informed_init, minimal_init, chebyshev_mapping,
-       logistic_mapping, modified_lm, weighted_minimal
-export rand_sparse, delay_line, delay_line_backward, cycle_jumps,
-       simple_cycle, pseudo_svd, chaotic_init, low_connectivity, double_cycle,
-       selfloop_cycle, selfloop_feedback_cycle, selfloop_delayline_backward,
-       selfloop_forward_connection, forward_connection, true_double_cycle
-export scale_radius!, delay_line!, backward_connection!, simple_cycle!,
-       reverse_simple_cycle!,
-       add_jumps!, self_loop!
+export chebyshev_mapping, informed_init, logistic_mapping, minimal_init,
+       modified_lm, scaled_rand, weighted_init, weighted_minimal
+export block_diagonal, chaotic_init, cycle_jumps, delay_line, delay_line_backward,
+       double_cycle, forward_connection, low_connectivity, pseudo_svd, rand_sparse,
+       selfloop_cycle, selfloop_delayline_backward, selfloop_feedback_cycle,
+       selfloop_forward_connection, simple_cycle, true_double_cycle
+export add_jumps!, backward_connection!, delay_line!, reverse_simple_cycle!,
+       scale_radius!, self_loop!, simple_cycle!
 export RNN, MRNN, GRU, GRUParams, FullyGated, Minimal
 export train
 export ESN, HybridESN, KnowledgeModel, DeepESN

--- a/test/esn/test_inits.jl
+++ b/test/esn/test_inits.jl
@@ -19,31 +19,32 @@ end
 
 ft = [Float16, Float32, Float64]
 reservoir_inits = [
-    rand_sparse,
+    block_diagonal,
+    chaotic_init,
+    cycle_jumps,
     delay_line,
     delay_line_backward,
-    cycle_jumps,
-    simple_cycle,
-    pseudo_svd,
-    chaotic_init,
-    low_connectivity,
     double_cycle,
-    selfloop_cycle,
-    selfloop_feedback_cycle,
-    selfloop_delayline_backward,
-    selfloop_forward_connection,
     forward_connection,
+    low_connectivity,
+    pseudo_svd,
+    rand_sparse,
+    selfloop_cycle,
+    selfloop_delayline_backward,
+    selfloop_feedback_cycle,
+    selfloop_forward_connection,
+    simple_cycle,
     true_double_cycle
 ]
 input_inits = [
-    scaled_rand,
-    weighted_init,
-    weighted_minimal,
-    minimal_init,
-    minimal_init(; sampling_type = :irrational_sample!),
     chebyshev_mapping,
     logistic_mapping,
-    modified_lm(; factor = 4)
+    minimal_init,
+    minimal_init(; sampling_type = :irrational_sample!),
+    modified_lm(; factor = 4),
+    scaled_rand,
+    weighted_init,
+    weighted_minimal
 ]
 
 @testset "Reservoir Initializers" begin


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Adds the initializer introduced in Ma, Haochun, et al. "Efficient forecasting of chaotic systems with block-diagonal and binary reservoir computing." Chaos: An Interdisciplinary Journal of Nonlinear Science 33.6 (2023).
