### PR TITLE
Improve explicit imports hygiene

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -34,6 +34,7 @@ CellularAutomata = "0.0.6"
 Compat = "4.16.0"
 ConcreteStructs = "0.2.3"
 DifferentialEquations = "7.16.1"
+ExplicitImports = "1.14.0"
 JET = "0.9, 0.10.10, 0.11"
 LIBSVM = "0.8"
 LinearAlgebra = "1.10"
@@ -53,6 +54,7 @@ julia = "1.10"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LIBSVM = "b1bec4e5-fd48-53fe-b0cb-9723c09d164b"
 MLJLinearModels = "6ee0df7b-362f-4a72-a706-9e79364fb692"
@@ -62,4 +64,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Test", "SafeTestsets", "DifferentialEquations", "MLJLinearModels", "LIBSVM", "Statistics", "SparseArrays", "JET"]
+test = ["Aqua", "ExplicitImports", "Test", "SafeTestsets", "DifferentialEquations", "MLJLinearModels", "LIBSVM", "Statistics", "SparseArrays", "JET"]

--- a/src/ReservoirComputing.jl
+++ b/src/ReservoirComputing.jl
@@ -3,16 +3,16 @@ module ReservoirComputing
 using ArrayInterface: ArrayInterface
 using Compat: @compat
 using ConcreteStructs: @concrete
-using LinearAlgebra: eigvals, mul!, I, qr, Diagonal, diag
+using LinearAlgebra: eigvals, I, qr, Diagonal, diag
 using LuxCore: AbstractLuxLayer, AbstractLuxContainerLayer, AbstractLuxWrapperLayer,
                setup, apply, replicate
 import LuxCore: initialparameters, initialstates, statelength, outputsize
-using NNlib: fast_act, sigmoid
+using NNlib: NNlib
 using Random: Random, AbstractRNG, randperm
-using Static: StaticBool, StaticInt, StaticSymbol,
-              True, False, static, known, dynamic, StaticInteger
+using Static: StaticBool, StaticSymbol, True, False, static, known, StaticInteger
 using Reexport: Reexport, @reexport
-using WeightInitializers: DeviceAgnostic, PartialFunction, Utils
+using WeightInitializers: WeightInitializers, DeviceAgnostic, PartialFunction, Utils,
+                          orthogonal, rand32, randn32, sparse_init, zeros32
 @reexport using WeightInitializers
 @reexport using LuxCore: setup, apply, initialparameters, initialstates
 

--- a/test/qa.jl
+++ b/test/qa.jl
@@ -1,4 +1,4 @@
-using ReservoirComputing, Aqua, JET
+using ReservoirComputing, Aqua, ExplicitImports, JET
 
 @testset "Aqua" begin
     Aqua.find_persistent_tasks_deps(ReservoirComputing)
@@ -9,6 +9,11 @@ using ReservoirComputing, Aqua, JET
     Aqua.test_stale_deps(ReservoirComputing)
     Aqua.test_unbound_args(ReservoirComputing)
     Aqua.test_undefined_exports(ReservoirComputing)
+end
+
+@testset "ExplicitImports" begin
+    @test check_no_implicit_imports(ReservoirComputing) === nothing
+    @test check_no_stale_explicit_imports(ReservoirComputing) === nothing
 end
 
 JET.test_package(ReservoirComputing;


### PR DESCRIPTION
## Summary

- Add explicit imports for WeightInitializers functions (`orthogonal`, `rand32`, `randn32`, `sparse_init`, `zeros32`) that were previously relying on implicit imports via `@reexport`
- Remove stale explicit imports:
  - `mul!` from LinearAlgebra (unused)
  - `fast_act`, `sigmoid` from NNlib (unused)  
  - `StaticInt`, `dynamic` from Static (unused)
- Add ExplicitImports.jl tests to CI for regression prevention
- Move ExplicitImports to test dependencies only

## Files Changed

- `src/ReservoirComputing.jl` - Fixed imports
- `test/qa.jl` - Added ExplicitImports tests
- `Project.toml` - Added ExplicitImports as test dependency

## Test plan

- [x] Ran `check_no_implicit_imports(ReservoirComputing)` - passes
- [x] Ran `check_no_stale_explicit_imports(ReservoirComputing)` - passes
- [x] Full test suite passes locally

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)