### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,4 +1,0 @@
-style = "sciml"
-format_markdown = false
-format_docstrings = true
-annotate_untyped_fields_with_any = false

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,13 +1,19 @@
-name: "Format Check"
+name: format-check
 
 on:
   push:
     branches:
       - 'master'
+      - 'main'
+      - 'release-'
     tags: '*'
   pull_request:
 
 jobs:
-  format-check:
-    name: "Format Check"
-    uses: "SciML/.github/.github/workflows/format-check.yml@v1"
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,16 +17,20 @@ links = InterLinks(
     "Lux" => "https://lux.csail.mit.edu/stable/"
 )
 
-makedocs(; modules = [ReservoirComputing],
+makedocs(;
+    modules = [ReservoirComputing],
     sitename = "ReservoirComputing.jl",
     clean = true, doctest = false, linkcheck = true,
     plugins = [links, bib],
     format = Documenter.HTML(;
         mathengine,
         assets = ["assets/favicon.ico"],
-        canonical = "https://docs.sciml.ai/ReservoirComputing/stable/"),
+        canonical = "https://docs.sciml.ai/ReservoirComputing/stable/"
+    ),
     pages = pages
 )
 
-deploydocs(; repo = "github.com/SciML/ReservoirComputing.jl.git",
-    push_preview = true)
+deploydocs(;
+    repo = "github.com/SciML/ReservoirComputing.jl.git",
+    push_preview = true
+)

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -8,7 +8,8 @@ pages = [
         #"Using Different Training Methods" => "esn_tutorials/different_training.md",
         "Deep Echo State Networks" => "tutorials/deep_esn.md",
         #"Hybrid Echo State Networks" => "tutorials/hybrid.md",
-        "Reservoir Computing with Cellular Automata" => "tutorials/reca.md"],
+        "Reservoir Computing with Cellular Automata" => "tutorials/reca.md",
+    ],
     "Examples" => Any[
         "Building a model to add to ReservoirComputing.jl" => "examples/model_es2n.md",
     ],
@@ -19,6 +20,7 @@ pages = [
         "Train" => "api/train.md",
         "Predict" => "api/predict.md",
         "States" => "api/states.md",
-        "Initializers" => "api/inits.md"],
-    "References" => "references.md"
+        "Initializers" => "api/inits.md",
+    ],
+    "References" => "references.md",
 ]

--- a/ext/RCCellularAutomataExt.jl
+++ b/ext/RCCellularAutomataExt.jl
@@ -1,6 +1,6 @@
 module RCCellularAutomataExt
 using ReservoirComputing: RECA, AbstractInputEncoding, ReservoirComputer,
-                          IntegerType, LinearReadout, StatefulLayer
+    IntegerType, LinearReadout, StatefulLayer
 import ReservoirComputing: RECACell, RECA, RandomMapping, RandomMaps
 using CellularAutomata
 using Random: randperm
@@ -10,7 +10,8 @@ function create_encoding(rm::RandomMapping, in_dims::IntegerType, generations::I
     states_size = generations * rm.expansion_size * rm.permutations
     ca_size = rm.expansion_size * rm.permutations
     return RandomMaps(
-        rm.permutations, rm.expansion_size, generations, maps, states_size, ca_size)
+        rm.permutations, rm.expansion_size, generations, maps, states_size, ca_size
+    )
 end
 
 function encoding(rm::RandomMaps, input_vector, tot_encoded_vector)
@@ -22,18 +23,21 @@ function encoding(rm::RandomMaps, input_vector, tot_encoded_vector)
         new_tot_enc_vec[((i - 1) * rm.expansion_size + 1):(i * rm.expansion_size)] = single_encoding(
             input_vector,
             new_tot_enc_vec[((i - 1) * rm.expansion_size + 1):(i * rm.expansion_size)],
-            rm.maps[i,
-            :])
+            rm.maps[
+                i,
+                :,
+            ]
+        )
     end
 
     return new_tot_enc_vec
 end
 
 function single_encoding(input_vector, encoded_vector, map)
-    @assert length(map)==length(input_vector) """
-      RandomMaps mismatch: map length = $(length(map)) but input length = $(length(input_vector)).
-      (Build RandomMaps with in_dims = size(input, 1) used at training time.)
-      """
+    @assert length(map) == length(input_vector) """
+    RandomMaps mismatch: map length = $(length(map)) but input length = $(length(input_vector)).
+    (Build RandomMaps with in_dims = size(input, 1) used at training time.)
+    """
     new_enc_vec = copy(encoded_vector)
 
     for i in 1:size(input_vector, 1)
@@ -76,18 +80,20 @@ function (reca::RECACell)(inp::AbstractVector, ps, st::NamedTuple)
     return reca((inp, (ca,)), ps, st)
 end
 
-function RECA(in_dims::IntegerType,
+function RECA(
+        in_dims::IntegerType,
         out_dims::IntegerType,
         automaton;
         input_encoding::AbstractInputEncoding = RandomMapping(),
         generations::Integer = 8,
         state_modifiers = (),
-        readout_activation = identity)
+        readout_activation = identity
+    )
     rm = create_encoding(input_encoding, in_dims, generations)
     cell = RECACell(automaton, rm)
 
     mods = state_modifiers isa Tuple || state_modifiers isa AbstractVector ?
-           Tuple(state_modifiers) : (state_modifiers,)
+        Tuple(state_modifiers) : (state_modifiers,)
 
     ro = LinearReadout(rm.states_size => out_dims, readout_activation)
 

--- a/ext/RCLIBSVMExt.jl
+++ b/ext/RCLIBSVMExt.jl
@@ -2,12 +2,14 @@ module RCLIBSVMExt
 
 using LIBSVM
 using ReservoirComputing:
-                          SVMReadout, addreadout!, ReservoirChain
+    SVMReadout, addreadout!, ReservoirChain
 import ReservoirComputing: train
 
-function train(svr::LIBSVM.AbstractSVR,
-        states::AbstractArray, target::AbstractArray)
-    @assert size(states, 2)==size(target, 2) "states and target must share columns."
+function train(
+        svr::LIBSVM.AbstractSVR,
+        states::AbstractArray, target::AbstractArray
+    )
+    @assert size(states, 2) == size(target, 2) "states and target must share columns."
     perm_states = permutedims(states)
     size_target = size(target, 1)
 

--- a/ext/RCMLJLinearModelsExt.jl
+++ b/ext/RCMLJLinearModelsExt.jl
@@ -2,10 +2,12 @@ module RCMLJLinearModelsExt
 using ReservoirComputing
 using MLJLinearModels
 
-function ReservoirComputing.train(regressor::MLJLinearModels.GeneralizedLinearRegression,
+function ReservoirComputing.train(
+        regressor::MLJLinearModels.GeneralizedLinearRegression,
         states::AbstractMatrix{<:Real}, target::AbstractMatrix{<:Real};
-        kwargs...)
-    @assert size(states, 2)==size(target, 2) "states and target must share the same number of columns."
+        kwargs...
+    )
+    @assert size(states, 2) == size(target, 2) "states and target must share the same number of columns."
 
     if regressor.fit_intercept
         throw(ArgumentError("fit_intercept=true not supported here. \

--- a/src/ReservoirComputing.jl
+++ b/src/ReservoirComputing.jl
@@ -5,14 +5,14 @@ using Compat: @compat
 using ConcreteStructs: @concrete
 using LinearAlgebra: eigvals, I, qr, Diagonal, diag, mul!
 using LuxCore: AbstractLuxLayer, AbstractLuxContainerLayer, AbstractLuxWrapperLayer,
-               setup, apply, replicate
+    setup, apply, replicate
 import LuxCore: initialparameters, initialstates, statelength, outputsize
 using NNlib: tanh_fast
 using Random: Random, AbstractRNG, randperm
 using Static: StaticBool, StaticSymbol, True, False, static, known, StaticInteger
 using Reexport: Reexport, @reexport
 using WeightInitializers: WeightInitializers, DeviceAgnostic, PartialFunction, Utils,
-                          orthogonal, rand32, randn32, sparse_init, zeros32
+    orthogonal, rand32, randn32, sparse_init, zeros32
 @reexport using WeightInitializers
 @reexport using LuxCore: setup, apply, initialparameters, initialstates
 
@@ -51,18 +51,18 @@ include("extensions/reca.jl")
 export ReservoirComputer
 export ESNCell, ES2NCell, EuSNCell
 export StatefulLayer, LinearReadout, ReservoirChain, Collect, collectstates,
-       DelayLayer, NonlinearFeaturesLayer
+    DelayLayer, NonlinearFeaturesLayer
 export SVMReadout
 export Pad, Extend, NLAT1, NLAT2, NLAT3, PartialSquare, ExtendedSquare
 export StandardRidge
 export chebyshev_mapping, informed_init, logistic_mapping, minimal_init,
-       modified_lm, scaled_rand, weighted_init, weighted_minimal
+    modified_lm, scaled_rand, weighted_init, weighted_minimal
 export block_diagonal, chaotic_init, cycle_jumps, delay_line, delayline_backward,
-       double_cycle, forward_connection, low_connectivity, pseudo_svd, rand_sparse,
-       selfloop_cycle, selfloop_delayline_backward, selfloop_backward_cycle,
-       selfloop_forwardconnection, simple_cycle, true_doublecycle, permutation_init
+    double_cycle, forward_connection, low_connectivity, pseudo_svd, rand_sparse,
+    selfloop_cycle, selfloop_delayline_backward, selfloop_backward_cycle,
+    selfloop_forwardconnection, simple_cycle, true_doublecycle, permutation_init
 export add_jumps!, backward_connection!, delay_line!, reverse_simple_cycle!,
-       scale_radius!, self_loop!, simple_cycle!, permute_matrix!
+    scale_radius!, self_loop!, simple_cycle!, permute_matrix!
 export train, train!, predict, resetcarry!, polynomial_monomials
 export ES2N, ESN, EuSN, DeepESN, DelayESN, HybridESN
 export NGRC

--- a/src/extensions/reca.jl
+++ b/src/extensions/reca.jl
@@ -57,11 +57,11 @@ struct RandomMapping{I, T} <: AbstractInputEncoding
 end
 
 function RandomMapping(; permutations = 8, expansion_size = 40)
-    RandomMapping(permutations, expansion_size)
+    return RandomMapping(permutations, expansion_size)
 end
 
 function RandomMapping(permutations; expansion_size = 40)
-    RandomMapping(permutations, expansion_size)
+    return RandomMapping(permutations, expansion_size)
 end
 
 struct RandomMaps{T, E, G, M, S} <: AbstractEncodingData
@@ -133,10 +133,12 @@ and [Yilmaz2014](@cite).
 end
 
 function Base.show(io::IO, reca::RECACell)
-    print(io,
+    return print(
+        io,
         "RECACell(in ⇒ ", reca.enc.ca_size, ", out=", reca.enc.states_size,
         ", gens=", reca.enc.generations, ", perms=", reca.enc.permutations,
-        ", exp=", reca.enc.expansion_size, ")")
+        ", exp=", reca.enc.expansion_size, ")"
+    )
 end
 
 initialparameters(::AbstractRNG, ::RECACell) = NamedTuple()

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -10,19 +10,27 @@ abstract type AbstractReservoirComputer{Fields} <: AbstractLuxContainerLayer{Fie
 function safe_getproperty(x, ::Union{Val{v}, StaticSymbol{v}}) where {v}
     return v in Base.propertynames(x) ? Base.getproperty(x, v) : nothing
 end
-@generated function safe_getproperty(x::NamedTuple{names}, ::Union{
-        Val{v}, StaticSymbol{v}}) where {
-        names, v}
+@generated function safe_getproperty(
+        x::NamedTuple{names}, ::Union{
+            Val{v}, StaticSymbol{v},
+        }
+    ) where {
+        names, v,
+    }
     return v in names ? :(x.$v) : :(nothing)
 end
 
-function dense_bias(generic_mat::AbstractMatrix,
+function dense_bias(
+        generic_mat::AbstractMatrix,
         generic_vec::AbstractVecOrMat,
-        bias::AbstractVector)
+        bias::AbstractVector
+    )
     return generic_mat * generic_vec .+ bias
 end
 
-function dense_bias(generic_mat::AbstractMatrix,
-        generic_vec::AbstractVecOrMat, ::Nothing)
+function dense_bias(
+        generic_mat::AbstractMatrix,
+        generic_vec::AbstractVecOrMat, ::Nothing
+    )
     return generic_mat * generic_vec
 end

--- a/src/inits/inits_input.jl
+++ b/src/inits/inits_input.jl
@@ -96,8 +96,10 @@ julia> res_input = scaled_rand(8, 3, scaling = [(0.1, 0.2), (-0.2, -0.1), (0.3, 
  0.101491  -0.103286  0.43553
 ```
 """
-function scaled_rand(rng::AbstractRNG, ::Type{T}, dims::Integer...;
-        scaling::Union{Number, Tuple, Vector} = T(0.1)) where {T <: Number}
+function scaled_rand(
+        rng::AbstractRNG, ::Type{T}, dims::Integer...;
+        scaling::Union{Number, Tuple, Vector} = T(0.1)
+    ) where {T <: Number}
     res_size, in_size = dims
     layer_matrix = DeviceAgnostic.rand(rng, T, res_size, in_size)
     apply_scale!(layer_matrix, scaling, T)
@@ -252,9 +254,11 @@ julia> res_input = weighted_init(9, 3; return_sparse = true)
    ⋅           ⋅         -0.0352914
 ```
 """
-function weighted_init(rng::AbstractRNG, ::Type{T}, dims::Integer...;
+function weighted_init(
+        rng::AbstractRNG, ::Type{T}, dims::Integer...;
         scaling::Union{Number, Tuple, Vector} = T(0.1),
-        return_sparse::Bool = false) where {T <: Number}
+        return_sparse::Bool = false
+    ) where {T <: Number}
     throw_sparse_error(return_sparse)
     approx_res_size, in_size = dims
     res_size = Int(floor(approx_res_size / in_size) * in_size)
@@ -371,9 +375,11 @@ julia> res_input = weighted_minimal(8, 3)
  0.0  0.0  0.1
 ```
 """
-function weighted_minimal(rng::AbstractRNG, ::Type{T}, dims::Integer...;
+function weighted_minimal(
+        rng::AbstractRNG, ::Type{T}, dims::Integer...;
         weight::Number = T(0.1), return_sparse::Bool = false,
-        sampling_type = :no_sample, kwargs...) where {T <: Number}
+        sampling_type = :no_sample, kwargs...
+    ) where {T <: Number}
     throw_sparse_error(return_sparse)
     approx_res_size, in_size = dims
     res_size = Int(floor(approx_res_size / in_size) * in_size)
@@ -413,9 +419,11 @@ networks [Pathak2018](@cite).
 
 ## Examples
 """
-function informed_init(rng::AbstractRNG, ::Type{T}, dims::Integer...;
+function informed_init(
+        rng::AbstractRNG, ::Type{T}, dims::Integer...;
         scaling::Number = T(0.1), model_in_size::Integer,
-        gamma::Number = T(0.5)) where {T <: Number}
+        gamma::Number = T(0.5)
+    ) where {T <: Number}
     res_size, in_size = dims
     state_size = in_size - model_in_size
 
@@ -447,8 +455,10 @@ function informed_init(rng::AbstractRNG, ::Type{T}, dims::Integer...;
         random_row_idx = rand(rng, candidate_row_indices)
         random_clm_idx = rand(rng, 1:state_size)
 
-        input_matrix[random_row_idx, random_clm_idx] = (DeviceAgnostic.rand(rng, T) -
-                                                        T(0.5)) * (T(2) * T(scaling))
+        input_matrix[random_row_idx, random_clm_idx] = (
+            DeviceAgnostic.rand(rng, T) -
+                T(0.5)
+        ) * (T(2) * T(scaling))
     end
 
     for _ in 1:num_for_model
@@ -458,8 +468,10 @@ function informed_init(rng::AbstractRNG, ::Type{T}, dims::Integer...;
         random_row_idx = rand(rng, candidate_row_indices)
         random_clm_idx = rand(rng, (state_size + 1):in_size)
 
-        input_matrix[random_row_idx, random_clm_idx] = (DeviceAgnostic.rand(rng, T) -
-                                                        T(0.5)) * (T(2) * T(scaling))
+        input_matrix[random_row_idx, random_clm_idx] = (
+            DeviceAgnostic.rand(rng, T) -
+                T(0.5)
+        ) * (T(2) * T(scaling))
     end
 
     return input_matrix
@@ -559,9 +571,11 @@ julia> res_input = minimal_init(8, 3; p = 0.8)# higher p -> more positive signs
  0.1   0.1  0.1
 ```
 """
-function minimal_init(rng::AbstractRNG, ::Type{T}, dims::Integer...;
+function minimal_init(
+        rng::AbstractRNG, ::Type{T}, dims::Integer...;
         weight::Number = T(0.1), sampling_type::Symbol = :bernoulli_sample!,
-        kwargs...) where {T <: Number}
+        kwargs...
+    ) where {T <: Number}
     res_size, in_size = dims
     input_matrix = DeviceAgnostic.zeros(rng, T, res_size, in_size)
     input_matrix .+= T(weight)
@@ -630,10 +644,12 @@ julia> input_matrix = chebyshev_mapping(10, 3)
  0.866025  0.866025  -4.37114f-8
 ```
 """
-function chebyshev_mapping(rng::AbstractRNG, ::Type{T}, dims::Integer...;
+function chebyshev_mapping(
+        rng::AbstractRNG, ::Type{T}, dims::Integer...;
         amplitude::AbstractFloat = one(T), sine_divisor::AbstractFloat = one(T),
         chebyshev_parameter::AbstractFloat = one(T),
-        return_sparse::Bool = false) where {T <: Number}
+        return_sparse::Bool = false
+    ) where {T <: Number}
     throw_sparse_error(return_sparse)
     input_matrix = DeviceAgnostic.zeros(rng, T, dims...)
     n_rows, n_cols = dims[1], dims[2]
@@ -643,8 +659,13 @@ function chebyshev_mapping(rng::AbstractRNG, ::Type{T}, dims::Integer...;
     end
     for idx_rows in 2:n_rows
         for idx_cols in 1:n_cols
-            input_matrix[idx_rows, idx_cols] = cos(chebyshev_parameter * acos(input_matrix[
-                idx_rows - 1, idx_cols]))
+            input_matrix[idx_rows, idx_cols] = cos(
+                chebyshev_parameter * acos(
+                    input_matrix[
+                        idx_rows - 1, idx_cols,
+                    ]
+                )
+            )
         end
     end
 
@@ -706,22 +727,24 @@ julia> logistic_mapping(8, 3)
 
 ```
 """
-function logistic_mapping(rng::AbstractRNG, ::Type{T}, dims::Integer...;
+function logistic_mapping(
+        rng::AbstractRNG, ::Type{T}, dims::Integer...;
         amplitude::AbstractFloat = 0.3, sine_divisor::AbstractFloat = 5.9,
         logistic_parameter::AbstractFloat = 3.7,
-        return_sparse::Bool = false) where {T <: Number}
+        return_sparse::Bool = false
+    ) where {T <: Number}
     throw_sparse_error(return_sparse)
     input_matrix = DeviceAgnostic.zeros(rng, T, dims...)
     num_rows, num_columns = dims[1], dims[2]
     for idx_col in 1:num_columns
         input_matrix[1, idx_col] = amplitude *
-                                   sin(idx_col * pi / (sine_divisor * num_columns))
+            sin(idx_col * pi / (sine_divisor * num_columns))
     end
     for idx_row in 2:num_rows
         for idx_col in 1:num_columns
             previous_value = input_matrix[idx_row - 1, idx_col]
             input_matrix[idx_row, idx_col] = logistic_parameter * previous_value *
-                                             (1 - previous_value)
+                (1 - previous_value)
         end
     end
 
@@ -804,10 +827,12 @@ julia> modified_lm(12, 4; factor=3)
 
 ```
 """
-function modified_lm(rng::AbstractRNG, ::Type{T}, dims::Integer...;
+function modified_lm(
+        rng::AbstractRNG, ::Type{T}, dims::Integer...;
         factor::Integer, amplitude::AbstractFloat = 0.3,
         sine_divisor::AbstractFloat = 5.9, logistic_parameter::AbstractFloat = 2.35,
-        return_sparse::Bool = false) where {T <: Number}
+        return_sparse::Bool = false
+    ) where {T <: Number}
     throw_sparse_error(return_sparse)
     num_columns = dims[2]
     expected_num_rows = factor * num_columns
@@ -820,13 +845,15 @@ function modified_lm(rng::AbstractRNG, ::Type{T}, dims::Integer...;
     output_matrix = DeviceAgnostic.zeros(rng, T, expected_num_rows, num_columns)
     for idx_col in 1:num_columns
         base_row = (idx_col - 1) * factor + 1
-        output_matrix[base_row, idx_col] = amplitude * sin(((idx_col - 1) * pi) /
-                                               (factor * num_columns * sine_divisor))
+        output_matrix[base_row, idx_col] = amplitude * sin(
+            ((idx_col - 1) * pi) /
+                (factor * num_columns * sine_divisor)
+        )
         for jdx in 1:(factor - 1)
             current_row = base_row + jdx
             previous_value = output_matrix[current_row - 1, idx_col]
             output_matrix[current_row, idx_col] = logistic_parameter * previous_value *
-                                                  (1 - previous_value)
+                (1 - previous_value)
         end
     end
 

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -61,15 +61,20 @@ before this layer (logically inserting a [`Collect`](@ref) right before it).
 end
 
 function LinearReadout(
-        mapping::Pair{<:IntegerType, <:IntegerType}, activation = identity; kwargs...)
+        mapping::Pair{<:IntegerType, <:IntegerType}, activation = identity; kwargs...
+    )
     return LinearReadout(first(mapping), last(mapping), activation; kwargs...)
 end
 
-function LinearReadout(in_dims::IntegerType, out_dims::IntegerType, activation = identity;
+function LinearReadout(
+        in_dims::IntegerType, out_dims::IntegerType, activation = identity;
         init_weight = rand32, init_bias = rand32, include_collect::BoolType = True(),
-        use_bias::BoolType = False())
-    return LinearReadout(activation, in_dims, out_dims, init_weight,
-        init_bias, static(use_bias), static(include_collect))
+        use_bias::BoolType = False()
+    )
+    return LinearReadout(
+        activation, in_dims, out_dims, init_weight,
+        init_bias, static(use_bias), static(include_collect)
+    )
 end
 
 function initialparameters(rng::AbstractRNG, ro::LinearReadout)
@@ -361,7 +366,7 @@ function Base.show(io::IO, dl::DelayLayer)
         end
     end
 
-    print(io, ")")
+    return print(io, ")")
 end
 
 @doc raw"""
@@ -465,5 +470,5 @@ function Base.show(io::IO, nfl::NonlinearFeaturesLayer)
         print(io, ", include_input=false")
     end
 
-    print(io, ")")
+    return print(io, ")")
 end

--- a/src/layers/es2n_cell.jl
+++ b/src/layers/es2n_cell.jl
@@ -80,19 +80,25 @@ Created by `initialstates(rng, esn)`:
     use_bias <: StaticBool
 end
 
-function ES2NCell((in_dims, out_dims)::Pair{<:IntegerType, <:IntegerType},
+function ES2NCell(
+        (in_dims, out_dims)::Pair{<:IntegerType, <:IntegerType},
         activation = tanh_fast; use_bias::BoolType = False(), init_bias = zeros32,
         init_reservoir = rand_sparse, init_input = scaled_rand,
         init_state = randn32, init_orthogonal = orthogonal,
-        proximity::AbstractFloat = 1.0)
-    return ES2NCell(activation, in_dims, out_dims, init_bias, init_reservoir,
-        init_input, init_orthogonal, init_state, proximity, static(use_bias))
+        proximity::AbstractFloat = 1.0
+    )
+    return ES2NCell(
+        activation, in_dims, out_dims, init_bias, init_reservoir,
+        init_input, init_orthogonal, init_state, proximity, static(use_bias)
+    )
 end
 
 function initialparameters(rng::AbstractRNG, esn::ES2NCell)
-    ps = (input_matrix = esn.init_input(rng, esn.out_dims, esn.in_dims),
+    ps = (
+        input_matrix = esn.init_input(rng, esn.out_dims, esn.in_dims),
         reservoir_matrix = esn.init_reservoir(rng, esn.out_dims, esn.out_dims),
-        orthogonal_matrix = esn.init_orthogonal(rng, esn.out_dims, esn.out_dims))
+        orthogonal_matrix = esn.init_orthogonal(rng, esn.out_dims, esn.out_dims),
+    )
     if has_bias(esn)
         ps = merge(ps, (bias = esn.init_bias(rng, esn.out_dims),))
     end
@@ -107,7 +113,7 @@ function (esn::ES2NCell)((inp, (hidden_state,))::InputType, ps, st::NamedTuple)
     w_state = dense_bias(ps.reservoir_matrix, hidden_state, bias)
     candidate_h = esn.activation.(win_inp .+ w_state)
     h_new = (one(T) - t_prox) .* ps.orthogonal_matrix * hidden_state .+
-            t_prox .* candidate_h
+        t_prox .* candidate_h
     return (h_new, (h_new,)), st
 end
 
@@ -117,5 +123,5 @@ function Base.show(io::IO, esn::ES2NCell)
         print(io, ", proximity=$(esn.proximity)")
     end
     has_bias(esn) || print(io, ", use_bias=false")
-    print(io, ")")
+    return print(io, ")")
 end

--- a/src/layers/esn_cell.jl
+++ b/src/layers/esn_cell.jl
@@ -78,17 +78,23 @@ Created by `initialstates(rng, esn)`:
     use_bias <: StaticBool
 end
 
-function ESNCell((in_dims, out_dims)::Pair{<:IntegerType, <:IntegerType},
+function ESNCell(
+        (in_dims, out_dims)::Pair{<:IntegerType, <:IntegerType},
         activation = tanh_fast; use_bias::BoolType = False(), init_bias = zeros32,
         init_reservoir = rand_sparse, init_input = scaled_rand,
-        init_state = randn32, leak_coefficient::AbstractFloat = 1.0)
-    return ESNCell(activation, in_dims, out_dims, init_bias, init_reservoir,
-        init_input, init_state, leak_coefficient, static(use_bias))
+        init_state = randn32, leak_coefficient::AbstractFloat = 1.0
+    )
+    return ESNCell(
+        activation, in_dims, out_dims, init_bias, init_reservoir,
+        init_input, init_state, leak_coefficient, static(use_bias)
+    )
 end
 
 function initialparameters(rng::AbstractRNG, esn::AbstractEchoStateNetworkCell)
-    ps = (input_matrix = esn.init_input(rng, esn.out_dims, esn.in_dims),
-        reservoir_matrix = esn.init_reservoir(rng, esn.out_dims, esn.out_dims))
+    ps = (
+        input_matrix = esn.init_input(rng, esn.out_dims, esn.in_dims),
+        reservoir_matrix = esn.init_reservoir(rng, esn.out_dims, esn.out_dims),
+    )
     if has_bias(esn)
         ps = merge(ps, (bias = esn.init_bias(rng, esn.out_dims),))
     end
@@ -122,5 +128,5 @@ function Base.show(io::IO, esn::ESNCell)
         print(io, ", leak_coefficient=$(esn.leak_coefficient)")
     end
     has_bias(esn) || print(io, ", use_bias=false")
-    print(io, ")")
+    return print(io, ")")
 end

--- a/src/layers/eusn_cell.jl
+++ b/src/layers/eusn_cell.jl
@@ -79,13 +79,17 @@ Created by `initialstates(rng, esn)`:
     use_bias <: StaticBool
 end
 
-function EuSNCell((in_dims, out_dims)::Pair{<:IntegerType, <:IntegerType},
+function EuSNCell(
+        (in_dims, out_dims)::Pair{<:IntegerType, <:IntegerType},
         activation = tanh_fast; use_bias::BoolType = False(), init_bias = zeros32,
         init_reservoir = rand_sparse, init_input = scaled_rand,
         init_state = randn32, leak_coefficient::AbstractFloat = 1.0,
-        diffusion::AbstractFloat = 1.0)
-    return EuSNCell(activation, in_dims, out_dims, init_bias, init_reservoir,
-        init_input, init_state, leak_coefficient, diffusion, static(use_bias))
+        diffusion::AbstractFloat = 1.0
+    )
+    return EuSNCell(
+        activation, in_dims, out_dims, init_bias, init_reservoir,
+        init_input, init_state, leak_coefficient, diffusion, static(use_bias)
+    )
 end
 
 function (esn::EuSNCell)((inp, (hidden_state,))::InputType, ps, st::NamedTuple)
@@ -110,10 +114,10 @@ function Base.show(io::IO, esn::EuSNCell)
         print(io, ", diffusion=$(esn.diffusion)")
     end
     has_bias(esn) || print(io, ", use_bias=false")
-    print(io, ")")
+    return print(io, ")")
 end
 
 function compute_asym_recurrent(weight_hh::AbstractMatrix, gamma::AbstractFloat)
     return weight_hh .- transpose(weight_hh) .-
-           gamma .* Matrix{eltype(weight_hh)}(I, size(weight_hh, 1), size(weight_hh, 1))
+        gamma .* Matrix{eltype(weight_hh)}(I, size(weight_hh, 1), size(weight_hh, 1))
 end

--- a/src/layers/svmreadout.jl
+++ b/src/layers/svmreadout.jl
@@ -1,4 +1,3 @@
-
 """
     SVMReadout(in_dims => out_dims;
         include_collect=true, kwargs...)
@@ -30,12 +29,14 @@ function Base.show(io::IO, ro::SVMReadout)
 end
 
 function SVMReadout(mapping::Pair{<:IntegerType, <:IntegerType}; kwargs...)
-    SVMReadout(first(mapping), last(mapping); kwargs...)
+    return SVMReadout(first(mapping), last(mapping); kwargs...)
 end
 
-function SVMReadout(in_dims::IntegerType, out_dims::IntegerType;
-        include_collect::BoolType = True())
-    SVMReadout(in_dims, out_dims, static(include_collect))
+function SVMReadout(
+        in_dims::IntegerType, out_dims::IntegerType;
+        include_collect::BoolType = True()
+    )
+    return SVMReadout(in_dims, out_dims, static(include_collect))
 end
 
 initialparameters(::AbstractRNG, ::SVMReadout) = NamedTuple()
@@ -48,7 +49,7 @@ outputsize(ro::SVMReadout, _, ::AbstractRNG) = (ro.out_dims,)
 
 function _svmreadout_include_collect(ro::SVMReadout)
     ic = known(getproperty(ro, Val(:include_collect)))
-    ic === nothing ? false : ic
+    return ic === nothing ? false : ic
 end
 
 function wrap_functions_in_chain_call(ro::SVMReadout)
@@ -83,12 +84,18 @@ end
     Kq = _quote_keys(K)
     tailKq = _quote_keys(tailK)
 
-    head_val = :((getfield(layers, 1) isa SVMReadout)
-                 ? _setmodels_rt(getfield(ps, 1), M)
-                 : getfield(ps, 1))
+    head_val = :(
+        (getfield(layers, 1) isa SVMReadout)
+            ? _setmodels_rt(getfield(ps, 1), M)
+            : getfield(ps, 1)
+    )
 
-    tail_call = :(_addsvm(NamedTuple{$tailKq}(Base.tail(layers)),
-        NamedTuple{$tailKq}(Base.tail(ps)), M))
+    tail_call = :(
+        _addsvm(
+            NamedTuple{$tailKq}(Base.tail(layers)),
+            NamedTuple{$tailKq}(Base.tail(ps)), M
+        )
+    )
 
     return :(NamedTuple{$Kq}(($head_val, Base.values($tail_call)...)))
 end
@@ -97,7 +104,7 @@ function addreadout!(rc::ReservoirChain, models, ps::NamedTuple, st::NamedTuple)
     @assert propertynames(rc.layers) == propertynames(ps)
     new_vals = map(Base.OneTo(length(propertynames(rc.layers)))) do i
         getfield(rc.layers, i) isa SVMReadout ? merge(getfield(ps, i), (models = models,)) :
-        getfield(ps, i)
+            getfield(ps, i)
     end
     new_ps = NamedTuple{propertynames(rc.layers)}(Tuple(new_vals))
     return new_ps, st

--- a/src/models/es2n.jl
+++ b/src/models/es2n.jl
@@ -77,20 +77,22 @@ Edge of Stability Echo State Network (ES2N) [Ceni2025](@cite).
 
 """
 @concrete struct ES2N <:
-                 AbstractEchoStateNetwork{(:reservoir, :states_modifiers, :readout)}
+    AbstractEchoStateNetwork{(:reservoir, :states_modifiers, :readout)}
     reservoir
     states_modifiers
     readout
 end
 
-function ES2N(in_dims::IntegerType, res_dims::IntegerType,
+function ES2N(
+        in_dims::IntegerType, res_dims::IntegerType,
         out_dims::IntegerType, activation = tanh;
         readout_activation = identity,
         state_modifiers = (),
-        kwargs...)
+        kwargs...
+    )
     cell = StatefulLayer(ES2NCell(in_dims => res_dims, activation; kwargs...))
     mods_tuple = state_modifiers isa Tuple || state_modifiers isa AbstractVector ?
-                 Tuple(state_modifiers) : (state_modifiers,)
+        Tuple(state_modifiers) : (state_modifiers,)
     mods = _wrap_layers(mods_tuple)
     ro = LinearReadout(res_dims => out_dims, readout_activation)
     return ES2N(cell, mods, ro)

--- a/src/models/esn.jl
+++ b/src/models/esn.jl
@@ -83,20 +83,22 @@ Composition:
 
 """
 @concrete struct ESN <:
-                 AbstractEchoStateNetwork{(:reservoir, :states_modifiers, :readout)}
+    AbstractEchoStateNetwork{(:reservoir, :states_modifiers, :readout)}
     reservoir
     states_modifiers
     readout
 end
 
-function ESN(in_dims::IntegerType, res_dims::IntegerType,
+function ESN(
+        in_dims::IntegerType, res_dims::IntegerType,
         out_dims::IntegerType, activation = tanh;
         readout_activation = identity,
         state_modifiers = (),
-        kwargs...)
+        kwargs...
+    )
     cell = StatefulLayer(ESNCell(in_dims => res_dims, activation; kwargs...))
     mods_tuple = state_modifiers isa Tuple || state_modifiers isa AbstractVector ?
-                 Tuple(state_modifiers) : (state_modifiers,)
+        Tuple(state_modifiers) : (state_modifiers,)
     mods = _wrap_layers(mods_tuple)
     ro = LinearReadout(res_dims => out_dims, readout_activation)
     return ESN(cell, mods, ro)

--- a/src/models/esn_delay.jl
+++ b/src/models/esn_delay.jl
@@ -1,4 +1,3 @@
-
 @doc raw"""
     DelayESN(in_dims, res_dims, out_dims, activation=tanh;
              num_delays=1, stride=1, leak_coefficient=1.0,
@@ -109,7 +108,7 @@ Composition:
   - `readout` — states for [`LinearReadout`](@ref) (typically empty).
 """
 @concrete struct DelayESN <:
-                 AbstractEchoStateNetwork{(:reservoir, :states_modifiers, :readout)}
+    AbstractEchoStateNetwork{(:reservoir, :states_modifiers, :readout)}
     reservoir
     states_modifiers
     readout
@@ -118,11 +117,12 @@ end
 function DelayESN(
         in_dims::IntegerType, res_dims::Int, out_dims::IntegerType, activation = tanh;
         num_delays::Int = 2, stride::Int = 1, readout_activation = identity,
-        state_modifiers = (), kwargs...)
+        state_modifiers = (), kwargs...
+    )
     cell = StatefulLayer(ESNCell(in_dims => res_dims, activation; kwargs...))
     delay = DelayLayer(res_dims; num_delays = num_delays, stride = stride)
     mods_tuple = state_modifiers isa Tuple || state_modifiers isa AbstractVector ?
-                 (delay, state_modifiers...) : (delay, state_modifiers)
+        (delay, state_modifiers...) : (delay, state_modifiers)
     mods = _wrap_layers(mods_tuple)
     ro_in_dims = res_dims * (num_delays + 1)
     ro = LinearReadout(ro_in_dims => out_dims, readout_activation)

--- a/src/models/esn_generics.jl
+++ b/src/models/esn_generics.jl
@@ -42,8 +42,8 @@ end
 @inline _asvec(x) = (ndims(x) == 2 ? vec(x) : x)
 
 function _coerce_layer_mods(x)
-    x === nothing ? () :
-    x isa Tuple ? x :
-    x isa AbstractVector ? Tuple(x) :
-    (x,)
+    return x === nothing ? () :
+        x isa Tuple ? x :
+        x isa AbstractVector ? Tuple(x) :
+        (x,)
 end

--- a/src/models/esn_hybrid.jl
+++ b/src/models/esn_hybrid.jl
@@ -1,4 +1,3 @@
-
 @doc raw"""
     HybridESN(km, km_dims, in_dims, res_dims, out_dims, [activation];
         state_modifiers=(), readout_activation=identity,
@@ -75,29 +74,36 @@ Created by `initialstates(rng, hesn)`:
 - `states_modifiers` — a `Tuple` with states for each modifier layer.
 - `readout` — states for [`LinearReadout`](@ref).
 """
-@concrete struct HybridESN <: AbstractEchoStateNetwork{(
-    :reservoir, :states_modifiers, :readout, :knowledge_model)}
+@concrete struct HybridESN <: AbstractEchoStateNetwork{
+        (
+            :reservoir, :states_modifiers, :readout, :knowledge_model,
+        ),
+    }
     reservoir
     knowledge_model
     states_modifiers
     readout
 end
 
-function HybridESN(km,
+function HybridESN(
+        km,
         km_dims::IntegerType, in_dims::IntegerType,
         res_dims::IntegerType, out_dims::IntegerType,
         activation = tanh;
         state_modifiers = (),
         readout_activation = identity,
         include_collect::BoolType = True(),
-        kwargs...)
+        kwargs...
+    )
     esn_inp_size = in_dims + km_dims
     reservoir = StatefulLayer(ESNCell(esn_inp_size => res_dims, activation; kwargs...))
     mods_tuple = state_modifiers isa Tuple || state_modifiers isa AbstractVector ?
-                 Tuple(state_modifiers) : (state_modifiers,)
+        Tuple(state_modifiers) : (state_modifiers,)
     mods = _wrap_layers(mods_tuple)
-    ro = LinearReadout(res_dims + km_dims => out_dims, readout_activation;
-        include_collect = static(include_collect))
+    ro = LinearReadout(
+        res_dims + km_dims => out_dims, readout_activation;
+        include_collect = static(include_collect)
+    )
     km_layer = km isa WrappedFunction ? km : WrappedFunction(km)
     return HybridESN(reservoir, km_layer, mods, ro)
 end
@@ -107,8 +113,10 @@ function initialparameters(rng::AbstractRNG, hesn::HybridESN)
     ps_km = initialparameters(rng, hesn.knowledge_model)
     ps_mods = map(l -> initialparameters(rng, l), hesn.states_modifiers) |> Tuple
     ps_ro = initialparameters(rng, hesn.readout)
-    return (reservoir = ps_reservoir, knowledge_model = ps_km,
-        states_modifiers = ps_mods, readout = ps_ro)
+    return (
+        reservoir = ps_reservoir, knowledge_model = ps_km,
+        states_modifiers = ps_mods, readout = ps_ro,
+    )
 end
 
 function initialstates(rng::AbstractRNG, hesn::HybridESN)
@@ -116,8 +124,10 @@ function initialstates(rng::AbstractRNG, hesn::HybridESN)
     st_km = initialstates(rng, hesn.knowledge_model)
     st_mods = map(l -> initialstates(rng, l), hesn.states_modifiers) |> Tuple
     st_ro = initialstates(rng, hesn.readout)
-    return (reservoir = st_reservoir, knowledge_model = st_km,
-        states_modifiers = st_mods, readout = st_ro)
+    return (
+        reservoir = st_reservoir, knowledge_model = st_km,
+        states_modifiers = st_mods, readout = st_ro,
+    )
 end
 
 function _partial_apply(hesn::HybridESN, inp, ps, st)
@@ -125,10 +135,10 @@ function _partial_apply(hesn::HybridESN, inp, ps, st)
     xin = vcat(k_t, inp)
     r, st_reservoir = apply(hesn.reservoir, xin, ps.reservoir, st.reservoir)
     rstar,
-    st_mods = _apply_seq(hesn.states_modifiers, r, ps.states_modifiers, st.states_modifiers)
+        st_mods = _apply_seq(hesn.states_modifiers, r, ps.states_modifiers, st.states_modifiers)
     feats = vcat(k_t, rstar)
     return feats,
-    (reservoir = st_reservoir, states_modifiers = st_mods, knowledge_model = st_km)
+        (reservoir = st_reservoir, states_modifiers = st_mods, knowledge_model = st_km)
 end
 
 function (hesn::HybridESN)(inp, ps, st)

--- a/src/models/eusn.jl
+++ b/src/models/eusn.jl
@@ -75,20 +75,22 @@ Euler State Network (ESN) [Gallicchio2024](@cite).
 
 """
 @concrete struct EuSN <:
-                 AbstractEchoStateNetwork{(:reservoir, :states_modifiers, :readout)}
+    AbstractEchoStateNetwork{(:reservoir, :states_modifiers, :readout)}
     reservoir
     states_modifiers
     readout
 end
 
-function EuSN(in_dims::IntegerType, res_dims::IntegerType,
+function EuSN(
+        in_dims::IntegerType, res_dims::IntegerType,
         out_dims::IntegerType, activation = tanh;
         readout_activation = identity,
         state_modifiers = (),
-        kwargs...)
+        kwargs...
+    )
     cell = StatefulLayer(EuSNCell(in_dims => res_dims, activation; kwargs...))
     mods_tuple = state_modifiers isa Tuple || state_modifiers isa AbstractVector ?
-                 Tuple(state_modifiers) : (state_modifiers,)
+        Tuple(state_modifiers) : (state_modifiers,)
     mods = _wrap_layers(mods_tuple)
     ro = LinearReadout(res_dims => out_dims, readout_activation)
     return EuSN(cell, mods, ro)

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -48,8 +48,10 @@ sequence.
 - `output`: Outputs for each input column, shape `(out_dims, T)`.
 - `st`: Updated minal model states.
 """
-function predict(rc::AbstractLuxLayer,
-        steps::Integer, ps, st; initialdata::AbstractVector)
+function predict(
+        rc::AbstractLuxLayer,
+        steps::Integer, ps, st; initialdata::AbstractVector
+    )
     output = zeros(eltype(initialdata), length(initialdata), steps)
     for step in 1:steps
         initialdata, st = apply(rc, initialdata, ps, st)
@@ -60,7 +62,7 @@ end
 
 function predict(rc::AbstractLuxLayer, data::AbstractMatrix, ps, st)
     T = size(data, 2)
-    @assert T≥1 "data must have at least one time step (columns)."
+    @assert T ≥ 1 "data must have at least one time step (columns)."
 
     y1, st = apply(rc, data[:, 1], ps, st)
     Y = similar(y1, size(y1, 1), T)

--- a/src/reservoircomputer.jl
+++ b/src/reservoircomputer.jl
@@ -1,4 +1,3 @@
-
 @doc raw"""
     ReservoirComputer(reservoir, states_modifiers, readout)
     ReservoirComputer(reservoir, readout)
@@ -31,14 +30,14 @@ features, and install trained readout weights.
   states of the reservoir, modifiers, and readout.
 """
 struct ReservoirComputer{R, S, L} <:
-       AbstractReservoirComputer{(:reservoir, :states_modifiers, :readout)}
+    AbstractReservoirComputer{(:reservoir, :states_modifiers, :readout)}
     reservoir::R
     states_modifiers::S
     readout::L
 
     function ReservoirComputer(reservoir::R, state_modifiers::S, readout::L) where {R, S, L}
         mods_tuple = state_modifiers isa Tuple || state_modifiers isa AbstractVector ?
-                     Tuple(state_modifiers) : (state_modifiers,)
+            Tuple(state_modifiers) : (state_modifiers,)
         mods = _wrap_layers(mods_tuple)
 
         return new{R, typeof(mods), L}(reservoir, mods, readout)
@@ -75,8 +74,9 @@ end
 function _partial_apply(rc::AbstractReservoirComputer, inp, ps, st)
     out, st_res = apply(rc.reservoir, inp, ps.reservoir, st.reservoir)
     out,
-    st_mods = _apply_seq(
-        rc.states_modifiers, out, ps.states_modifiers, st.states_modifiers)
+        st_mods = _apply_seq(
+        rc.states_modifiers, out, ps.states_modifiers, st.states_modifiers
+    )
     return out, (reservoir = st_res, states_modifiers = st_mods)
 end
 
@@ -87,7 +87,8 @@ function (rc::AbstractReservoirComputer)(inp, ps, st)
 end
 
 function collectstates(
-        rc::AbstractReservoirComputer, data::AbstractMatrix, ps, st::NamedTuple)
+        rc::AbstractReservoirComputer, data::AbstractMatrix, ps, st::NamedTuple
+    )
     newst = st
     nsteps = size(data, 2)
     cols = eachcol(data)
@@ -109,8 +110,10 @@ end
 
 _set_readout_weight(ps_readout::NamedTuple, wro) = merge(ps_readout, (; weight = wro))
 
-function addreadout!(::AbstractReservoirComputer, output_matrix::AbstractMatrix,
-        ps::NamedTuple, st::NamedTuple)
+function addreadout!(
+        ::AbstractReservoirComputer, output_matrix::AbstractMatrix,
+        ps::NamedTuple, st::NamedTuple
+    )
     @assert hasproperty(ps, :readout)
     new_readout = _set_readout_weight(ps.readout, output_matrix)
     return merge(ps, (readout = new_readout,)), st
@@ -179,7 +182,8 @@ function is provided, it is called to create a new initial hidden state.
 
 """
 function resetcarry!(
-        rng::AbstractRNG, rc::AbstractReservoirComputer, st; init_carry = nothing)
+        rng::AbstractRNG, rc::AbstractReservoirComputer, st; init_carry = nothing
+    )
     carry = get(st.reservoir, :carry, nothing)
     if carry === nothing
         outd = rc.reservoir.cell.out_dims
@@ -199,7 +203,9 @@ function resetcarry!(
     return merge(st, (reservoir = new_cell,))
 end
 
-function resetcarry!(rng::AbstractRNG, rc::AbstractReservoirComputer,
-        ps, st; init_carry = nothing)
+function resetcarry!(
+        rng::AbstractRNG, rc::AbstractReservoirComputer,
+        ps, st; init_carry = nothing
+    )
     return ps, resetcarry!(rng, rc, st; init_carry = init_carry)
 end

--- a/src/states.jl
+++ b/src/states.jl
@@ -1,7 +1,9 @@
-
 @inline function _apply_tomatrix(
-        states_mod::F, states::AbstractMatrix) where {F <:
-                                                      Function}
+        states_mod::F, states::AbstractMatrix
+    ) where {
+        F <:
+        Function,
+    }
     cols = axes(states, 2)
     states_1 = states_mod(states[:, first(cols)])
     new_states = similar(states_1, length(states_1), length(cols))

--- a/test/layers/test_basic.jl
+++ b/test/layers/test_basic.jl
@@ -68,8 +68,10 @@ using LinearAlgebra
     @testset "forward pass: matrix (batch), activation" begin
         ro = LinearReadout(2 => 2, tanh; use_bias = False())
         ps = (weight = Float32[1 0; 0 2],)
-        X = Float32[0.0 1.0 -1.0;
-                    0.5 0.5 0.5]
+        X = Float32[
+            0.0 1.0 -1.0;
+            0.5 0.5 0.5
+        ]
         Y, _ = ro(X, ps, NamedTuple())
         @test size(Y) == (2, 3)
         @test Y[:, 1] ≈ tanh.(ps.weight * X[:, 1])
@@ -98,8 +100,9 @@ using LinearAlgebra
             first_layer = getfield(L, 1)
             @test first_layer isa Collect
         catch e
-            @info "Skipping Collect insertion test (no auto-wrap for LinearReadout?)" exception=(
-                e, catch_backtrace())
+            @info "Skipping Collect insertion test (no auto-wrap for LinearReadout?)" exception = (
+                e, catch_backtrace(),
+            )
         end
     end
 end

--- a/test/layers/test_svmreadout.jl
+++ b/test/layers/test_svmreadout.jl
@@ -174,8 +174,8 @@ end
     idx_svm = findfirst(k -> getfield(rc.layers, k) isa SVMReadout, keys)
     ps_svm_entry = getfield(ps1, idx_svm)
     ps_svm = ps_svm_entry isa NamedTuple ? ps_svm_entry :
-             ps_svm_entry isa Expr ? (models = model,) :
-             (models = model,)
+        ps_svm_entry isa Expr ? (models = model,) :
+        (models = model,)
 
     x2d = randn(in_dims, 1)
     y_pred, _ = ro(x2d, ps_svm, NamedTuple())
@@ -203,8 +203,8 @@ end
     idx_svm = findfirst(k -> getfield(rc.layers, k) isa SVMReadout, keys)
     ps_svm_entry = getfield(ps1, idx_svm)
     ps_svm = ps_svm_entry isa NamedTuple ? ps_svm_entry :
-             ps_svm_entry isa Expr ? (models = model,) :
-             (models = model,)
+        ps_svm_entry isa Expr ? (models = model,) :
+        (models = model,)
 
     badx = randn(in_dims, 2, 2)
     @test_throws ArgumentError ro(badx, ps_svm, NamedTuple())

--- a/test/models/test_esn_deep.jl
+++ b/test/models/test_esn_deep.jl
@@ -10,14 +10,14 @@ const _O32 = (rng, m) -> zeros(Float32, m)
 const _W_I = (rng, m, n) -> _I32(m, n)
 const _W_ZZ = (rng, m, n) -> zeros(Float32, m, n)
 function init_state3(rng::AbstractRNG, m::Integer, B::Integer)
-    B == 1 ? zeros(Float32, m) : zeros(Float32, m, B)
+    return B == 1 ? zeros(Float32, m) : zeros(Float32, m, B)
 end
 
 function _pin_identity_readout(ps::NamedTuple; out_dims::Integer, in_dims::Integer)
     ro_ps = haskey(ps.readout, :bias) ?
-            (weight = _I32(out_dims, in_dims), bias = _Z32(out_dims)) :
-            (weight = _I32(out_dims, in_dims),)
-    merge(ps, (readout = ro_ps,))
+        (weight = _I32(out_dims, in_dims), bias = _Z32(out_dims)) :
+        (weight = _I32(out_dims, in_dims),)
+    return merge(ps, (readout = ro_ps,))
 end
 
 @testset "DeepESN model" begin
@@ -26,7 +26,8 @@ end
         in_dims = 4
         res_dims = [5, 6, 7]
         out_dims = 3
-        desn = DeepESN(in_dims, res_dims, out_dims, identity;
+        desn = DeepESN(
+            in_dims, res_dims, out_dims, identity;
             leak_coefficient = 1.0,
             init_reservoir = _W_ZZ,
             init_input = _W_I,
@@ -34,7 +35,8 @@ end
             init_state = init_state3,
             use_bias = False(),
             state_modifiers = nothing,
-            readout_activation = identity)
+            readout_activation = identity
+        )
         ps, st = setup(rng, desn)
         @test length(desn.cells) == length(res_dims)
         @test length(ps.cells) == length(res_dims)
@@ -48,7 +50,8 @@ end
         rng = MersenneTwister(2)
         D = 3
         depth = 3
-        desn = DeepESN(D, fill(D, depth), D, identity;
+        desn = DeepESN(
+            D, fill(D, depth), D, identity;
             leak_coefficient = 1.0,
             init_reservoir = _W_ZZ,
             init_input = _W_I,
@@ -56,7 +59,8 @@ end
             init_state = init_state3,
             use_bias = False(),
             state_modifiers = nothing,
-            readout_activation = identity)
+            readout_activation = identity
+        )
         ps, st = setup(rng, desn)
         ps = _pin_identity_readout(ps; out_dims = D, in_dims = D)
         x = Float32[1, 2, 3]
@@ -70,7 +74,8 @@ end
     @testset "forward: batch matrix, identity across layers" begin
         rng = MersenneTwister(3)
         D, B = 4, 5
-        desn = DeepESN(D, [D, D], D, identity;
+        desn = DeepESN(
+            D, [D, D], D, identity;
             leak_coefficient = 1.0,
             init_reservoir = _W_ZZ,
             init_input = _W_I,
@@ -78,7 +83,8 @@ end
             init_state = init_state3,
             use_bias = False(),
             state_modifiers = nothing,
-            readout_activation = identity)
+            readout_activation = identity
+        )
         ps, st = setup(rng, desn)
         ps = _pin_identity_readout(ps; out_dims = D, in_dims = D)
         X = reshape(Float32.(1:(D * B)), D, B)
@@ -91,7 +97,8 @@ end
         rng = MersenneTwister(4)
         D = 3
         mods = (x -> x .+ 1.0f0, x -> 2.0f0 .* x)
-        desn = DeepESN(D, [D, D], D, identity;
+        desn = DeepESN(
+            D, [D, D], D, identity;
             leak_coefficient = 1.0,
             init_reservoir = _W_ZZ,
             init_input = _W_I,
@@ -99,7 +106,8 @@ end
             init_state = init_state3,
             use_bias = False(),
             state_modifiers = mods,
-            readout_activation = identity)
+            readout_activation = identity
+        )
         ps, st = setup(rng, desn)
         ps = _pin_identity_readout(ps; out_dims = D, in_dims = D)
         x = Float32[0, 1, -2]
@@ -111,7 +119,8 @@ end
     @testset "depth convenience constructor" begin
         rng = MersenneTwister(5)
         D = 2
-        desn = DeepESN(D, D, D, identity; depth = 4,
+        desn = DeepESN(
+            D, D, D, identity; depth = 4,
             leak_coefficient = 1.0,
             init_reservoir = _W_ZZ,
             init_input = _W_I,
@@ -119,7 +128,8 @@ end
             init_state = init_state3,
             use_bias = False(),
             state_modifiers = nothing,
-            readout_activation = identity)
+            readout_activation = identity
+        )
         @test length(desn.cells) == 4
         ps, st = setup(rng, desn)
         ps = _pin_identity_readout(ps; out_dims = D, in_dims = D)
@@ -132,7 +142,8 @@ end
     @testset "resetcarry! sets carries using a function" begin
         rng = MersenneTwister(6)
         D = 3
-        desn = DeepESN(D, [4, 5], 2, identity;
+        desn = DeepESN(
+            D, [4, 5], 2, identity;
             leak_coefficient = 1.0,
             init_reservoir = _W_ZZ,
             init_input = _W_I,
@@ -140,7 +151,8 @@ end
             init_state = init_state3,
             use_bias = False(),
             state_modifiers = nothing,
-            readout_activation = identity)
+            readout_activation = identity
+        )
         ps, st = setup(rng, desn)
         f = (rng, m) -> ones(Float32, m)
         st2 = resetcarry!(rng, desn, st; init_carry = f)
@@ -154,7 +166,8 @@ end
     @testset "resetcarry! with per-layer initializers" begin
         rng = MersenneTwister(7)
         D = 3
-        desn = DeepESN(D, [D, D, D], D, identity;
+        desn = DeepESN(
+            D, [D, D, D], D, identity;
             leak_coefficient = 1.0,
             init_reservoir = _W_ZZ,
             init_input = _W_I,
@@ -162,7 +175,8 @@ end
             init_state = init_state3,
             use_bias = False(),
             state_modifiers = nothing,
-            readout_activation = identity)
+            readout_activation = identity
+        )
         st = initialstates(rng, desn)
         inits = ((rng, m) -> fill(1.0f0, m), nothing, (rng, m) -> fill(3.0f0, m))
         st2 = resetcarry!(rng, desn, st; init_carry = inits)
@@ -177,7 +191,8 @@ end
         rng = MersenneTwister(8)
         D = 3
         Tlen = 5
-        desn = DeepESN(D, [D, D], D, identity;
+        desn = DeepESN(
+            D, [D, D], D, identity;
             leak_coefficient = 1.0,
             init_reservoir = _W_ZZ,
             init_input = _W_I,
@@ -185,7 +200,8 @@ end
             init_state = init_state3,
             use_bias = False(),
             state_modifiers = nothing,
-            readout_activation = identity)
+            readout_activation = identity
+        )
         ps, st = setup(rng, desn)
         X = reshape(Float32.(1:(D * Tlen)), D, Tlen)
         S, st2 = collectstates(desn, X, ps, st)
@@ -197,7 +213,8 @@ end
     @testset "collectstates over vector" begin
         rng = MersenneTwister(9)
         D = 4
-        desn = DeepESN(D, [D], D, identity;
+        desn = DeepESN(
+            D, [D], D, identity;
             leak_coefficient = 1.0,
             init_reservoir = _W_ZZ,
             init_input = _W_I,
@@ -205,7 +222,8 @@ end
             init_state = init_state3,
             use_bias = False(),
             state_modifiers = nothing,
-            readout_activation = identity)
+            readout_activation = identity
+        )
         ps, st = setup(rng, desn)
         x = Float32[1, 2, 3, 4]
         S, _ = collectstates(desn, x, ps, st)

--- a/test/models/test_esn_delay.jl
+++ b/test/models/test_esn_delay.jl
@@ -13,8 +13,10 @@ using LinearAlgebra
         out_dims = 2
         num_delays = 2
 
-        desn = DelayESN(in_dims, res_dims, out_dims;
-            num_delays = num_delays, stride = 1)
+        desn = DelayESN(
+            in_dims, res_dims, out_dims;
+            num_delays = num_delays, stride = 1
+        )
 
         @test desn isa DelayESN
 

--- a/test/models/test_esn_hybrid.jl
+++ b/test/models/test_esn_hybrid.jl
@@ -10,14 +10,14 @@ const _O32 = (rng, m) -> zeros(Float32, m)
 const _W_I = (rng, m, n) -> _I32(m, n)
 const _W_ZZ = (rng, m, n) -> zeros(Float32, m, n)
 function init_state3(rng::AbstractRNG, m::Integer, B::Integer)
-    B == 1 ? zeros(Float32, m) : zeros(Float32, m, B)
+    return B == 1 ? zeros(Float32, m) : zeros(Float32, m, B)
 end
 
 function _pin_identity_readout(ps::NamedTuple; out_dims::Integer, in_dims::Integer)
     ro_ps = haskey(ps.readout, :bias) ?
-            (weight = _I32(out_dims, in_dims), bias = _Z32(out_dims)) :
-            (weight = _I32(out_dims, in_dims),)
-    merge(ps, (readout = ro_ps,))
+        (weight = _I32(out_dims, in_dims), bias = _Z32(out_dims)) :
+        (weight = _I32(out_dims, in_dims),)
+    return merge(ps, (readout = ro_ps,))
 end
 
 @testset "HybridESN model" begin
@@ -26,7 +26,8 @@ end
         km_dims, in_dims, res_dims = 2, 3, 5
         out_dims = res_dims + km_dims
         km = x -> ones(Float32, km_dims, size(x, 2))
-        hesn = HybridESN(km, km_dims, in_dims, res_dims, out_dims, identity;
+        hesn = HybridESN(
+            km, km_dims, in_dims, res_dims, out_dims, identity;
             use_bias = False(),
             init_input = _W_I,
             init_reservoir = _W_ZZ,
@@ -34,14 +35,15 @@ end
             init_state = init_state3,
             leak_coefficient = 1.0,
             state_modifiers = (),
-            readout_activation = identity)
+            readout_activation = identity
+        )
         ps, st = setup(rng, hesn)
         @test haskey(ps, :reservoir) && haskey(ps, :knowledge_model) &&
-              haskey(ps, :states_modifiers) && haskey(ps, :readout)
+            haskey(ps, :states_modifiers) && haskey(ps, :readout)
         @test size(ps.reservoir.input_matrix) == (res_dims, in_dims + km_dims)
         @test size(ps.readout.weight) == (out_dims, res_dims + km_dims)
         @test haskey(st, :reservoir) && haskey(st, :knowledge_model) &&
-              haskey(st, :states_modifiers) && haskey(st, :readout)
+            haskey(st, :states_modifiers) && haskey(st, :readout)
     end
 
     @testset "forward: vector as batch=1, identity pipeline with concatenated features" begin
@@ -50,7 +52,8 @@ end
         res_dims = in_dims + km_dims
         out_dims = res_dims + km_dims
         km = x -> ones(Float32, km_dims, size(x, 2))
-        hesn = HybridESN(km, km_dims, in_dims, res_dims, out_dims, identity;
+        hesn = HybridESN(
+            km, km_dims, in_dims, res_dims, out_dims, identity;
             use_bias = False(),
             init_input = _W_I,
             init_reservoir = _W_ZZ,
@@ -58,7 +61,8 @@ end
             init_state = init_state3,
             leak_coefficient = 1.0,
             state_modifiers = (),
-            readout_activation = identity)
+            readout_activation = identity
+        )
         ps, st = setup(rng, hesn)
         ps = _pin_identity_readout(ps; out_dims = out_dims, in_dims = res_dims + km_dims)
         x = Float32[1, 2, 3]
@@ -76,7 +80,8 @@ end
         res_dims = in_dims + km_dims
         out_dims = res_dims + km_dims
         km = x -> fill(2.0f0, km_dims, size(x, 2))
-        hesn = HybridESN(km, km_dims, in_dims, res_dims, out_dims, identity;
+        hesn = HybridESN(
+            km, km_dims, in_dims, res_dims, out_dims, identity;
             use_bias = False(),
             init_input = _W_I,
             init_reservoir = _W_ZZ,
@@ -84,7 +89,8 @@ end
             init_state = init_state3,
             leak_coefficient = 1.0,
             state_modifiers = (),
-            readout_activation = identity)
+            readout_activation = identity
+        )
         ps, st = setup(rng, hesn)
         ps = _pin_identity_readout(ps; out_dims = out_dims, in_dims = res_dims + km_dims)
         X = reshape(Float32.(1:(in_dims * B)), in_dims, B)
@@ -101,7 +107,8 @@ end
         res_dims = in_dims + km_dims
         out_dims = res_dims + km_dims
         km = x -> ones(Float32, km_dims, size(x, 2))
-        hesn = HybridESN(km, km_dims, in_dims, res_dims, out_dims, identity;
+        hesn = HybridESN(
+            km, km_dims, in_dims, res_dims, out_dims, identity;
             use_bias = False(),
             init_input = _W_I,
             init_reservoir = _W_ZZ,
@@ -109,7 +116,8 @@ end
             init_state = init_state3,
             leak_coefficient = 1.0,
             state_modifiers = (x -> 2.0f0 .* x,),
-            readout_activation = identity)
+            readout_activation = identity
+        )
         ps, st = setup(rng, hesn)
         ps = _pin_identity_readout(ps; out_dims = out_dims, in_dims = res_dims + km_dims)
         x = Float32[3, -1]
@@ -129,7 +137,8 @@ end
         res_dims = in_dims + km_dims
         out_dims = res_dims + km_dims
         km = x -> -ones(Float32, km_dims, size(x, 2))
-        hesn = HybridESN(km, km_dims, in_dims, res_dims, out_dims, identity;
+        hesn = HybridESN(
+            km, km_dims, in_dims, res_dims, out_dims, identity;
             use_bias = False(),
             init_input = _W_I,
             init_reservoir = _W_ZZ,
@@ -137,7 +146,8 @@ end
             init_state = init_state3,
             leak_coefficient = 1.0,
             state_modifiers = (),
-            readout_activation = x -> max.(x, 0.0f0))
+            readout_activation = x -> max.(x, 0.0f0)
+        )
         ps, st = setup(rng, hesn)
         ps = _pin_identity_readout(ps; out_dims = out_dims, in_dims = res_dims + km_dims)
         X = reshape(Float32[-2, 0, 5], :, 1)

--- a/test/models/test_ngrc.jl
+++ b/test/models/test_ngrc.jl
@@ -10,9 +10,11 @@ using Static
     square_feature = x -> x .^ 2
 
     @testset "constructor & composition" begin
-        ngrc = NGRC(3, 2; num_delays = 1, stride = 2,
+        ngrc = NGRC(
+            3, 2; num_delays = 1, stride = 2,
             features = (const_feature, square_feature), include_input = True(),
-            init_delay = zeros32, readout_activation = tanh)
+            init_delay = zeros32, readout_activation = tanh
+        )
 
         @test ngrc isa NGRC
         @test ngrc.reservoir isa DelayLayer
@@ -29,8 +31,10 @@ using Static
     end
 
     @testset "initialparameters & initialstates" begin
-        ngrc = NGRC(3, 2; num_delays = 1, features = (square_feature,),
-            include_input = True())
+        ngrc = NGRC(
+            3, 2; num_delays = 1, features = (square_feature,),
+            include_input = True()
+        )
 
         ps = initialparameters(rng, ngrc)
         st = initialstates(rng, ngrc)
@@ -47,8 +51,10 @@ using Static
     end
 
     @testset "forward pass: vector input" begin
-        ngrc = NGRC(3, 2; num_delays = 1, features = (square_feature,),
-            include_input = True())
+        ngrc = NGRC(
+            3, 2; num_delays = 1, features = (square_feature,),
+            include_input = True()
+        )
 
         ps, st = setup(rng, ngrc)
 
@@ -60,8 +66,10 @@ using Static
     end
 
     @testset "forward pass: matrix input via collectstates" begin
-        ngrc = NGRC(3, 2; num_delays = 1, features = (square_feature,),
-            include_input = True())
+        ngrc = NGRC(
+            3, 2; num_delays = 1, features = (square_feature,),
+            include_input = True()
+        )
 
         ps, st = setup(rng, ngrc)
 
@@ -87,13 +95,17 @@ using Static
         X_in = reshape(x[1:(end - 1)], 1, :)
         Y_out = reshape(x[2:end], 1, :)
 
-        ngrc = NGRC(1, 1; num_delays = 0, stride = 1, features = (),
-            include_input = True(), ro_dims = 1)
+        ngrc = NGRC(
+            1, 1; num_delays = 0, stride = 1, features = (),
+            include_input = True(), ro_dims = 1
+        )
 
         ps, st = setup(rng, ngrc)
 
-        ps_tr, st_tr = train!(ngrc, X_in, Y_out, ps, st;
-            train_method = StandardRidge(1e-6))
+        ps_tr, st_tr = train!(
+            ngrc, X_in, Y_out, ps, st;
+            train_method = StandardRidge(1.0e-6)
+        )
 
         @test hasproperty(ps_tr, :readout)
         w = ps_tr.readout.weight

--- a/test/qa.jl
+++ b/test/qa.jl
@@ -16,7 +16,8 @@ end
     @test check_no_stale_explicit_imports(ReservoirComputing) === nothing
 end
 
-JET.test_package(ReservoirComputing;
+JET.test_package(
+    ReservoirComputing;
     target_modules = (ReservoirComputing,),
     toplevel_logger = nothing
 )

--- a/test/test_inits.jl
+++ b/test/test_inits.jl
@@ -5,7 +5,7 @@ const in_size = 4
 const radius = 1.0
 const rng = Random.default_rng()
 
-function check_radius(matrix, target_radius; tolerance = 1e-5)
+function check_radius(matrix, target_radius; tolerance = 1.0e-5)
     if matrix isa SparseArrays.SparseMatrixCSC
         matrix = Matrix(matrix)
     end
@@ -32,7 +32,7 @@ reservoir_inits = [
     selfloop_forwardconnection,
     simple_cycle,
     true_doublecycle,
-    permutation_init
+    permutation_init,
 ]
 input_inits = [
     chebyshev_mapping,
@@ -42,7 +42,7 @@ input_inits = [
     modified_lm(; factor = 4),
     scaled_rand,
     weighted_init,
-    weighted_minimal
+    weighted_minimal,
 ]
 
 @testset "Reservoir Initializers" begin
@@ -64,19 +64,19 @@ input_inits = [
     end
 
     @testset "Minimum complexity: $init" for init in [
-        delay_line,
-        delayline_backward,
-        cycle_jumps,
-        simple_cycle,
-        true_doublecycle,
-        double_cycle,
-        selfloop_cycle,
-        selfloop_delayline_backward,
-        selfloop_backward_cycle,
-        selfloop_forwardconnection,
-        forward_connection,
-        permutation_init
-    ]
+            delay_line,
+            delayline_backward,
+            cycle_jumps,
+            simple_cycle,
+            true_doublecycle,
+            double_cycle,
+            selfloop_cycle,
+            selfloop_delayline_backward,
+            selfloop_backward_cycle,
+            selfloop_forwardconnection,
+            forward_connection,
+            permutation_init,
+        ]
         dl = init(res_size, res_size)
         @test sort(unique(dl)) == Float32.([0.0, 0.1])
     end
@@ -97,9 +97,9 @@ end
     end
 
     @testset "Minimum complexity: $init" for init in [
-        minimal_init,
-        minimal_init(; sampling_type = :irrational_sample!)
-    ]
+            minimal_init,
+            minimal_init(; sampling_type = :irrational_sample!),
+        ]
         dl = init(res_size, in_size)
         @test sort(unique(dl)) == Float32.([-0.1, 0.1])
     end

--- a/test/test_states.jl
+++ b/test/test_states.jl
@@ -11,7 +11,8 @@ nlas = [
     (NLAT3(), [1, 2, 8, 4, 24, 6, 48, 8, 9]),
     (PartialSquare(0.6), [1, 4, 9, 16, 25, 6, 7, 8, 9]),
     (ExtendedSquare(), [1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 4, 9, 16, 25, 36, 49, 64, 81]),
-    (Pad(padding), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])]
+    (Pad(padding), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+]
 
 @testset "States Testing" for T in test_types
     @testset "Nonlinear Algorithms Testing: $algo $T" for (algo, expected_output) in nlas


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)