### PR TITLE
Documentation improvements: Fix typos and improve clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle)
 [![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 [![Julia](https://img.shields.io/badge/julia-v1.10+-blue.svg)](https://julialang.org/)
-[![JET](https://img.shields.io/badge/%E2%9C%88%EF%B8%8F%20tested%20with%20-%20JET.jl%20-%20red)](jet-urlhttps://github.com/aviatesk/JET.jl)
+[![JET](https://img.shields.io/badge/%E2%9C%88%EF%B8%8F%20tested%20with%20-%20JET.jl%20-%20red)](https://github.com/aviatesk/JET.jl)
 
 </div>
 
@@ -57,7 +57,7 @@ reservoir computing models. More specifically the software offers:
 ReservoirComputing.jl can be installed using either of
 
 ```julia_repl
-julia> ] #actually press the closing square brackets
+julia> ] # press the closing square bracket to enter Pkg mode
 pkg> add ReservoirComputing
 ```
 or

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -17,7 +17,7 @@ Pkg.add("ReservoirComputing")
 ## Copy-Pastable Simplified Example
 
 If you wish to just get some code running to get started, the following code
-block provides an end=to-end simplified runnable example. The rest of this
+block provides an end-to-end simplified runnable example. The rest of this
 page will delve into more details, expanding on various aspects of the example.
 
 ```@example first-esn
@@ -156,7 +156,7 @@ the best results.
 ## Training and Prediction
 
 Training for ESNs usually means solving a linear regression. The library supports
-solvers from ['MLILinearModels.jl'](https://github.com/JuliaAI/MLJLinearModels.jl),
+solvers from [MLJLinearModels.jl](https://github.com/JuliaAI/MLJLinearModels.jl),
 in addition to a custom implementation of ridge regression [`StandardRidge`](@ref).
 In this example we will use the latter.
 

--- a/docs/src/tutorials/lorenz_basic.md
+++ b/docs/src/tutorials/lorenz_basic.md
@@ -44,7 +44,7 @@ test_data = data[:, (shift + train_len + 1):(shift + train_len + predict_len)]
 ```
 
 It is *important* to notice that the data needs to be formatted in a
-matrix with the features as rows and time steps as columns as in this example
+matrix with the features as rows and time steps as columns as in this example.
 This is needed even if the time series consists of single values.
 
 ## Building the Echo State Network
@@ -87,13 +87,13 @@ The value of `input_scaling` determines the upper and lower bounds of the
 uniform distribution of the weights in the [`weighted_init`](@ref).
 The value of 0.1 represents the default. The default input layer is
 the [`scaled_rand`](@ref), a dense matrix. The details of the weighted version
-can be found in [Lu2017](@cite), for this example, this version returns
+can be found in [Lu2017](@cite). For this example, this version returns
 the best results.
 
 ## Training and Prediction
 
-Training for ESNs usually means solving a linear regression. The libbrary supports
-solvers from ['MLILinearModels.jl'](https://github.com/JuliaAI/MLJLinearModels.jl),
+Training for ESNs usually means solving a linear regression. The library supports
+solvers from [MLJLinearModels.jl](https://github.com/JuliaAI/MLJLinearModels.jl),
 in addition to a custom implementation of ridge regression. In this example we will
 use the latter.
 

--- a/docs/src/tutorials/scratch.md
+++ b/docs/src/tutorials/scratch.md
@@ -1,6 +1,6 @@
 # Building a model from scratch
 
-ReservoirComputing.jl provides utilities to build reservoir reservoir
+ReservoirComputing.jl provides utilities to build reservoir
 computing models from scratch. In this tutorial we are going to build
 an echo state network ([`ESN`](@ref)) and showcase how this custom
 implementation is equivalent to the provided model (minus some comfort
@@ -71,7 +71,7 @@ collection happens. In a [`ReservoirChain`](@ref), the collection of states is
 controlled by the layer [`Collect`](@ref). The role of this layer is to tell
 the [`collectstates`](@ref) function where to stop for state collection. All
 the readout layers have a `include_collect=true` keyword, which forces a
-[`Collect`](@ref) layer bvefore the readout. The model we wrote before can
+[`Collect`](@ref) layer before the readout. The model we wrote before can
 be written as
 
 ```@example scratch


### PR DESCRIPTION
This PR fixes several typos and improves clarity across the documentation.

## Changes Made

### README.md
- Fixed broken JET badge URL (removed erroneous `jet-url` prefix)
- Improved installation instructions clarity (changed "actually press" to clearer wording)

### docs/src/getting_started.md
- Fixed typo: "end=to-end" → "end-to-end"
- Fixed incorrect package name in markdown link: `'MLILinearModels.jl'` → `[MLJLinearModels.jl]`

### docs/src/tutorials/lorenz_basic.md
- Added missing period after sentence about data formatting
- Fixed comma placement for better sentence flow
- Fixed typo: "libbrary" → "library"
- Fixed incorrect package name in markdown link (same as above)

### docs/src/tutorials/scratch.md
- Removed duplicate word: "reservoir reservoir" → "reservoir"
- Fixed typo: "bvefore" → "before"

All changes are minor fixes that improve documentation quality without changing any functionality or code examples.

@ChrisRackauckas