### PR TITLE
fix: wire EIESN and AdditiveEIESN tests into CI

### DIFF
--- a/test/layers/test_additiveeiesncell.jl
+++ b/test/layers/test_additiveeiesncell.jl
@@ -53,7 +53,7 @@ end
     @test haskey(ps, :bias_in)
     @test size(ps.bias_ex) == (4,)
 
-    cell_nobias = AdditiveEIESNCell(3 => 4; use_bias = false)
+    cell_nobias = AdditiveEIESNCell(3 => 4; use_bias = false, init_reservoir = _W_I)
     ps_nb = initialparameters(rng, cell_nobias)
 
     @test !haskey(ps_nb, :bias_ex)

--- a/test/layers/test_eiesncell.jl
+++ b/test/layers/test_eiesncell.jl
@@ -41,7 +41,7 @@ end
     @test haskey(ps, :bias_inh)
     @test size(ps.bias_ex) == (4,)
 
-    cell_nb = EIESNCell(3 => 4; use_bias = false)
+    cell_nb = EIESNCell(3 => 4; use_bias = false, init_reservoir = _W_I)
     ps_nb = initialparameters(rng, cell_nb)
 
     @test haskey(ps_nb, :input_matrix)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,8 @@ if GROUP == "All" || GROUP == "Core"
     @testset "Layers" begin
         @safetestset "Basic layers" include("layers/test_basic.jl")
         @safetestset "ESN Cell" include("layers/test_esncell.jl")
+        @safetestset "EIESN Cell" include("layers/test_eiesncell.jl")
+        @safetestset "AdditiveEIESN Cell" include("layers/test_additiveeiesncell.jl")
         @safetestset "SVMReadout" include("layers/test_svmreadout.jl")
     end
 
@@ -27,6 +29,8 @@ if GROUP == "All" || GROUP == "Core"
         @safetestset "DeepESN model" include("models/test_esn_deep.jl")
         @safetestset "DelayESN model" include("models/test_esn_delay.jl")
         @safetestset "HybridESN model" include("models/test_esn_hybrid.jl")
+        @safetestset "EIESN model" include("models/test_eiesn.jl")
+        @safetestset "AdditiveEIESN model" include("models/test_additiveeiesn.jl")
     end
 
     @testset "Next Generation Reservoir Computing" begin


### PR DESCRIPTION
## Summary

- Wire 4 existing test files into `test/runtests.jl` that were never included in the test runner:
  - `test/layers/test_eiesncell.jl` 
  - `test/layers/test_additiveeiesncell.jl`
  - `test/models/test_eiesn.jl`
  - `test/models/test_additiveeiesn.jl`
- Fix a bug in the no-bias test cases for `EIESNCell` and `AdditiveEIESNCell`: the default `rand_sparse` initializer produces NaN on a 4×4 reservoir matrix (too small for the default sparsity), causing test errors. Pass `init_reservoir = _W_I` since these tests only verify absence of bias keys.

These files and their source code were added in PRs #364 and #366 but the test runner was never updated to include them.

## Test plan

- [x] `GROUP=Core Pkg.test()` passes locally (all 887 tests pass including new EIESN tests)
- [x] `GROUP=nopre Pkg.test()` passes locally (13/13 QA tests pass)
- [x] Runic formatting check passes
- [ ] CI passes on all platforms/versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)