### PR TITLE
Adding a Wigner matrix initialiser for #284

### DIFF
--- a/src/inits/inits_reservoir.jl
+++ b/src/inits/inits_reservoir.jl
@@ -2538,38 +2538,51 @@ end
 
 function wigner_init(
         rng::AbstractRNG, ::Type{T}, dims::Integer...;
-        radius::Number = T(1.0), std::Number = T(1.0)
+        radius::Number = T(1.0), diagonal_std::Number, off_diagonal_std::Number,
+        return_symmetric::Bool = true
     ) where {T <: Number}
     # 1. Dimension check : Reservoir has to be a square matrix
     check_res_size(dims...)
     res_size = dims[1]  
 
-    # 2. Initialise the empty matrix using the requested type T
-    W = zeros(T, res_size, res_size)
+    # 2. Initialise the zeros matrix with type T
+    reservoir_matrix = zeros(T, res_size, res_size)
 
     # 3. Populating the matrix
-    # Diagonal elements sampled from N(0, 2*std^2)
-    # Off-diagonal elements sampled from N(0, std^2)
-    for i in 1 : res_size
-        for j in 1 : res_size
-            if i==j
-                # Diagonal element
-                W[i, j] = randn(rng, T) * T(sqrt(2)) * T(std)
-            else
-                # Off-diagonal elements (upper triangular part)
-                W[i, j] = randn(rng, T) * T(std)
+    # Diagonal elements sampled from N(0, diagonal_std^2)
+    # Off-diagonal elements sampled from N(0, off_diagonal_std^2)
+    
+    # Default symmetric case
+    if return_symmetric
+        # Efficient upper-triangle fill for symmetric matrices
+        for i in 1:res_size
+            for j in i:res_size
+                if i == j
+                    reservoir_matrix[i, j] = DeviceAgnostic.randn(rng, T) * T(diag_std)
+                else
+                    reservoir_matrix[i, j] = DeviceAgnostic.randn(rng, T) * T(off_diag_std)
+                end
+            end
+        end
+        # Mirror the matrix
+        reservoir_matrix = Symmetric(reservoir_matrix)
+        
+    # User sets return_symmetric=false
+    else
+        for i in 1:res_size
+            for j in 1:res_size
+                if i == j
+                    W[i, j] = DeviceAgnostic.randn(rng, T) * T(diag_std)
+                else
+                    W[i, j] = DeviceAgnostic.randn(rng, T) * T(off_diag_std)
+                end
             end
         end
     end
-
-    # Make the matrix symmetric
-    W = Symmetric(W)
-
-    # 4. Scaling the spectral radius to the user-specified value
-    W = scale_radius!(W, T(radius))
-
-    # 5. Check for NaN or Inf values
-    check_inf_nan(W)
-
-    return W
+    
+    #3. Scale the spectral radius
+    reservoir_matrix = scale_radius!(reservoir_matrix, T(radius))
+    
+    
+    return reservoir_matrix
 end

--- a/src/inits/inits_reservoir.jl
+++ b/src/inits/inits_reservoir.jl
@@ -2533,3 +2533,43 @@ for initializer in (
         end
     end
 end
+
+
+
+function wigner_init(
+        rng::AbstractRNG, ::Type{T}, dims::Integer...;
+        radius::Number = T(1.0), std::Number = T(1.0)
+    ) where {T <: Number}
+    # 1. Dimension check : Reservoir has to be a square matrix
+    check_res_size(dims...)
+    res_size = dims[1]  
+
+    # 2. Initialise the empty matrix using the requested type T
+    W = zeros(T, res_size, res_size)
+
+    # 3. Populating the matrix
+    # Diagonal elements sampled from N(0, 2*std^2)
+    # Off-diagonal elements sampled from N(0, std^2)
+    for i in 1 : res_size
+        for j in 1 : res_size
+            if i==j
+                # Diagonal element
+                W[i, j] = randn(rng, T) * T(sqrt(2)) * T(std)
+            else
+                # Off-diagonal elements (upper triangular part)
+                W[i, j] = randn(rng, T) * T(std)
+            end
+        end
+    end
+
+    # Make the matrix symmetric
+    W = Symmetric(W)
+
+    # 4. Scaling the spectral radius to the user-specified value
+    W = scale_radius!(W, T(radius))
+
+    # 5. Check for NaN or Inf values
+    check_inf_nan(W)
+
+    return W
+end

--- a/test/test_inits.jl
+++ b/test/test_inits.jl
@@ -110,12 +110,18 @@ end
     #rng = Random.default_rng()
     #res_size = 10
 
+    # Test for symmetric case (default)
+    symmetric_reservoir = wigner_init(rng, Float32, res_size; radius=1.2, diag_std=1.414, off_diag_std=1.0)
+    
+    @test size(symm) == (res_size, res_size)
+    @test eltype(symmetric_reservoir) == Float32
+    @test issymmetric(symmetric_reservoir)
 
-    W = wigner_init(rng, Float32, res_size; radius = 0.9, std = 0.5)
-
-    @test size(W) == (res_size, res_size)
-
-    @test eltype(W) == Float32
-
-    @test issymmetric(W)
+    # Test for asymmetric case
+    # We explicitly turn off symmetry
+    asymmetric_reservoir = wigner_init(rng, Float32, res_size; radius=1.2, diag_std=1.414, off_diag_std=1.0, return_symmetric=false)
+    
+    @test size(asymmetric_reservoir) == (res_size, res_size)
+    @test eltype(asymmetric_reservoir) == Float32
+    @test !issymmetric(asymmetric_reservoir) 
 end

--- a/test/test_inits.jl
+++ b/test/test_inits.jl
@@ -105,3 +105,17 @@ end
         @test sort(unique(dl)) == Float32.([-0.1, 0.1])
     end
 end
+
+@testset "Wigner_matrix_init.jl" begin
+    #rng = Random.default_rng()
+    #res_size = 10
+
+
+    W = wigner_init(rng, Float32, res_size; radius = 0.9, std = 0.5)
+
+    @test size(W) == (res_size, res_size)
+
+    @test eltype(W) == Float32
+
+    @test issymmetric(W)
+end


### PR DESCRIPTION
This PR implements the Wigner matrix initialisation to resolve Issue #284.

##  Changes Made
* Added `wigner_init` to the matrix initialisers.
* Utilised `LinearAlgebra.Symmetric` to make the matrix symmetric.
* Integrated the standard `check_res_size`, `scale_radius!`, and `check_inf_nan` utilities.
* Added a `@testset` block to verify reservoir dimensions, data type, and reservoir symmetry.
  
