### PR TITLE
Implement Lower Triangular Topology (#268)

### DIFF
--- a/docs/src/api/inits.md
+++ b/docs/src/api/inits.md
@@ -42,6 +42,8 @@ where full details and examples are provided.
     where each node connects forward by two steps.
 - [`low_connectivity`](inits/low_connectivity.md): Creates a low-degree
     random (or enforced cycle) connectivity reservoir.
+- [`lower_triangular`](inits/lower_triangular.md): Creates a reservoir with 
+    weights filled in diagonal and "lower" diagonals until a given sparsity is reached.  
 - [`permutation_init`](inits/permutation_init.md): Constructs a reservoir matrix that is
     a permutation of the identity matrix.
 - [`pseudo_svd`](inits/pseudo_svd.md): Builds a reservoir by iteratively

--- a/docs/src/api/inits/lower_triangular.md
+++ b/docs/src/api/inits/lower_triangular.md
@@ -1,0 +1,5 @@
+# Lower Triangular Topology
+
+```@docs
+    lower_triangular
+```

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -510,3 +510,13 @@
 	year = {2017},
 	pages = {10199},
 }
+
+@inproceedings{Cossu2025,
+  title = {Sparse Reservoir Topologies for Physical Implementations of Random Oscillators Networks},
+  url = {https://dl.acm.org/doi/10.1145/3703412.3703413},
+  doi = {10.1145/3703412.3703413},
+  booktitle = {Proceedings of the 4th International Conference on AI-ML Systems},
+  author = {Cossu, Andrea and Ceni, Andrea and Bacciu, Davide and Gallicchio, Claudio},
+  month = oct,
+  year = {2024}
+}

--- a/src/ReservoirComputing.jl
+++ b/src/ReservoirComputing.jl
@@ -65,7 +65,7 @@ export StandardRidge
 export chebyshev_mapping, informed_init, logistic_mapping, minimal_init,
     modified_lm, scaled_rand, weighted_init, weighted_minimal
 export block_diagonal, chaotic_init, cycle_jumps, delay_line, delayline_backward,
-    diagonal_init, double_cycle, forward_connection, low_connectivity, permutation_init,
+    diagonal_init, double_cycle, forward_connection, low_connectivity, lower_triangular, permutation_init,
     pseudo_svd, rand_hyper, rand_sparse, selfloop_backward_cycle, selfloop_cycle, selfloop_delayline_backward,
     selfloop_forwardconnection, simple_cycle, true_doublecycle, wigner_init
 export add_jumps!, backward_connection!, delay_line!, permute_matrix!, reverse_simple_cycle!,

--- a/src/inits/inits_reservoir.jl
+++ b/src/inits/inits_reservoir.jl
@@ -2732,14 +2732,124 @@ function wigner_init(
     return reservoir_matrix
 end
 
+@doc raw"""
+    lower_triangular([rng], [T], dims...; radius=1.0, sparsity=0.9, return_sparse=false)
+
+Create and return a sparse reservoir matrix with a lower triangular topology [Cossu2025](@cite).
+This function populates the main diagonal and the immediately adjacent lower sub-diagonals 
+with random uniform weights in the range `(-1, 1)` until the target `sparsity` is reached. 
+It guarantees structural symmetry by only adding complete diagonals.
+
+## Arguments
+
+  - `rng`: Random number generator. Default is `Utils.default_rng()` from
+    [WeightInitializers](https://lux.csail.mit.edu/stable/api/Building_Blocks/WeightInitializers).
+  - `T`: Type of the elements in the reservoir matrix. Default is `Float32`.
+  - `dims`: Dimensions of the reservoir matrix. Must be square.
+
+## Keyword arguments
+
+  - `radius`: The desired spectral radius of the reservoir. Defaults to 1.0.
+  - `sparsity`: The exact target fraction of zero elements in the matrix. 
+    To hit this target precisely while preventing spatial bias, 
+    any remaining weights needed for the final partial sub-diagonal are randomly distributed across its indices. 
+    Defaults to 0.9.
+  - `return_sparse`: Flag for returning a `SparseMatrixCSC` instead of a dense matrix. 
+    Setting to `true` requires `SparseArrays` to be loaded. Defaults to `false`.
+
+## Examples
+
+Default call:
+
+```jldoctest lowertriangular
+julia> W = lower_triangular(5, 5)
+5×5 Matrix{Float32}:
+ -0.214159   0.0         0.0        0.0        0.0
+  0.710328   0.655184    0.0        0.0        0.0
+ -0.912441   0.311545   -0.412411   0.0        0.0
+  0.0        0.114112    0.551211   0.812451   0.0
+  0.0        0.0        -0.741211   0.914141   0.115412
+```
+
+Returning a `SparseMatrixCSC`:
+
+```jldoctest lowertriangular
+julia> using SparseArrays
+
+julia> W_sparse = lower_triangular(6, 6; sparsity=0.8, return_sparse=true)
+6×6 SparseMatrixCSC{Float32, Int64} with 7 stored entries:
+  0.4512   ⋅        ⋅        ⋅        ⋅        ⋅
+  0.1245  -0.8123   ⋅        ⋅        ⋅        ⋅
+ -0.7612   0.9123  -0.1124   ⋅        ⋅        ⋅
+  ⋅        ⋅        0.4412  -0.5123   ⋅        ⋅
+  ⋅        ⋅        ⋅        ⋅        0.8812   ⋅
+  ⋅        ⋅        ⋅        ⋅        ⋅        0.3314
+```
+
+Scaling to a custom spectral radius:
+
+```jldoctest lowertriangular
+julia> W_scaled = lower_triangular(Float16, 4, 4; radius=2.5)
+4×4 Matrix{Float16}:
+  2.145   0.0     0.0     0.0
+ -1.123   1.854   0.0     0.0
+  0.954  -2.113  -1.542   0.0
+  0.0     1.412   2.014  -1.953
+```
+"""
+function lower_triangular(
+        rng::AbstractRNG, ::Type{T}, dims::Integer...;
+        radius = T(1.0), sparsity = 0.9, return_sparse = false
+    ) where {T <: Number}
+
+    throw_sparse_error(return_sparse)
+    check_res_size(dims...)
+    res_size = dims[1]
+
+    reservoir_matrix = DeviceAgnostic.zeros(rng, T, res_size, res_size)
+
+    weights = DeviceAgnostic.rand(rng, T, res_size) .* T(2.0) .- T(1.0)
+    self_loop!(rng, reservoir_matrix, weights)
+
+    target_non_zeros = round(Int, res_size * res_size * (1.0 - sparsity))
+    current_non_zeros = res_size # from the self-loops
+    shift = 1
+
+    while current_non_zeros < target_non_zeros && shift < res_size
+        diag_length = res_size - shift
+        remaining_non_zeros = target_non_zeros - current_non_zeros
+        if remaining_non_zeros >= diag_length
+            # Fill the entire diagonal
+            weights = DeviceAgnostic.rand(rng, T, diag_length) .* T(2.0) .- T(1.0)
+            current_non_zeros += diag_length
+        else
+            # We only need a fraction of this diagonal to hit the exact target
+            weights = DeviceAgnostic.zeros(rng, T, diag_length)
+
+            # Randomly distribute the remaining_non_zeros weights to avoid biasing the top-left
+            active_indices = Random.randperm(rng, diag_length)[1:remaining_non_zeros]
+            weights[active_indices] = DeviceAgnostic.rand(rng, T, remaining_non_zeros) .* T(2.0) .- T(1.0)
+
+            current_non_zeros += remaining_non_zeros
+        end
+
+        delay_line!(rng, reservoir_matrix, weights, shift)
+        shift += 1
+    end
+
+    scale_radius!(reservoir_matrix, radius)
+
+    return return_init_as(Val(return_sparse), reservoir_matrix)
+end
+
 ### fallbacks
 #fallbacks for initializers #eventually to remove once migrated to WeightInitializers.jl
 for initializer in (
         :rand_sparse, :delay_line, :delayline_backward, :cycle_jumps,
         :simple_cycle, :pseudo_svd, :chaotic_init, :scaled_rand, :weighted_init,
         :weighted_minimal, :informed_init, :minimal_init, :chebyshev_mapping,
-        :logistic_mapping, :modified_lm, :low_connectivity, :double_cycle, :selfloop_cycle,
-        :selfloop_backward_cycle, :selfloop_delayline_backward, :selfloop_forwardconnection,
+        :logistic_mapping, :modified_lm, :low_connectivity, :lower_triangular, :double_cycle,
+        :selfloop_cycle, :selfloop_backward_cycle, :selfloop_delayline_backward, :selfloop_forwardconnection,
         :forward_connection, :true_doublecycle, :block_diagonal, :permutation_init,
         :diagonal_init, :wigner_init, :rand_hyper,
     )
@@ -2768,83 +2878,4 @@ for initializer in (
             return PartialFunction.Partial{Nothing}($initializer, nothing, kwargs)
         end
     end
-end
-
-"""
-    lower_triangular([rng], [T], dims...; radius=1.0, sparsity=0.9, return_sparse=false)
-
-Create and return a sparse reservoir matrix with a lower triangular topology.
-This function populates the main diagonal and the immediately adjacent lower sub-diagonals 
-with random uniform weights in the range `(-1, 1)` until the target `sparsity` is reached. 
-It guarantees structural symmetry by only adding complete diagonals.
-
-## Arguments
- - `rng`: Random number generator. 
- - `T`: Type of the elements in the reservoir matrix (e.g., `Float16`, `Float32`).
- - `dims`: Dimensions of the reservoir matrix. Must be square.
-
-
-## Keyword arguments
- - `radius`: The desired spectral radius of the reservoir. Defaults to 1.0.
- - `sparsity`: The exact target fraction of zero elements in the matrix. 
-    To hit this target precisely while preventing spatial bias, 
-    any remaining weights needed for the final partial sub-diagonal are randomly distributed across its indices. 
-    Defaults to 0.9.
- - `return_sparse`: Flag for returning a `SparseMatrixCSC` instead of a dense matrix. 
-   Setting to `true` requires `SparseArrays` to be loaded. Defaults to `false`.
-
-## Examples
-```jldoctest
-julia> W = lower_triangular(5, 5; sparsity=0.6)
-5×5 Matrix{Float32}:
- -0.214159   0.0        0.0        0.0       0.0
-  0.710328   0.655184   0.0        0.0       0.0
- -0.912441   0.311545  -0.412411   0.0       0.0
-  0.0        0.114112   0.551211   0.812451  0.0
-  0.0        0.0       -0.741211   0.914141  0.115412
-
-"""
-
-
-function lower_triangular(rng::AbstractRNG, ::Type{T}, dims::Integer...; 
-                          radius=T(1.0), sparsity=0.9, return_sparse=false) where {T <: Number}
-    
-    throw_sparse_error(return_sparse)
-    check_res_size(dims...)
-    res_size = dims[1]
-    
-    reservoir_matrix = DeviceAgnostic.zeros(rng, T, res_size, res_size)
-    
-    weights = DeviceAgnostic.rand(rng, T, res_size) .* T(2.0) .- T(1.0)
-    self_loop!(rng, reservoir_matrix, weights)
-
-    target_non_zeros = round(Int, res_size * res_size * (1.0 - sparsity))
-    current_non_zeros = res_size # from the self-loops
-    shift = 1
-
-    while current_non_zeros < target_non_zeros && shift < res_size
-        diag_length = res_size - shift
-        remaining_non_zeros = target_non_zeros - current_non_zeros
-        if remaining_non_zeros >= diag_length
-          # Fill the entire diagonal
-          weights = DeviceAgnostic.rand(rng, T, diag_length) .* T(2.0) .- T(1.0)
-          current_non_zeros += diag_length
-        else
-          # We only need a fraction of this diagonal to hit the exact target
-          weights = DeviceAgnostic.zeros(rng, T, diag_length)
-            
-          # Randomly distribute the remaining_non_zeros weights to avoid biasing the top-left
-          active_indices = DeviceAgnostic.randperm(rng, diag_length)[1:remaining_non_zeros]
-          weights[active_indices] = DeviceAgnostic.rand(rng, T, remaining_non_zeros) .* T(2.0) .- T(1.0)
-            
-          current_non_zeros += remaining_non_zeros
-        end
-        
-        delay_line!(rng, reservoir_matrix, weights, shift)
-        shift += 1
-    end
-    
-    scale_radius!(reservoir_matrix, radius)
-    
-    return return_init_as(Val(return_sparse), reservoir_matrix)
 end

--- a/src/inits/inits_reservoir.jl
+++ b/src/inits/inits_reservoir.jl
@@ -2769,3 +2769,82 @@ for initializer in (
         end
     end
 end
+
+"""
+    lower_triangular([rng], [T], dims...; radius=1.0, sparsity=0.9, return_sparse=false)
+
+Create and return a sparse reservoir matrix with a lower triangular topology.
+This function populates the main diagonal and the immediately adjacent lower sub-diagonals 
+with random uniform weights in the range `(-1, 1)` until the target `sparsity` is reached. 
+It guarantees structural symmetry by only adding complete diagonals.
+
+## Arguments
+ - `rng`: Random number generator. 
+ - `T`: Type of the elements in the reservoir matrix (e.g., `Float16`, `Float32`).
+ - `dims`: Dimensions of the reservoir matrix. Must be square.
+
+
+## Keyword arguments
+ - `radius`: The desired spectral radius of the reservoir. Defaults to 1.0.
+ - `sparsity`: The exact target fraction of zero elements in the matrix. 
+    To hit this target precisely while preventing spatial bias, 
+    any remaining weights needed for the final partial sub-diagonal are randomly distributed across its indices. 
+    Defaults to 0.9.
+ - `return_sparse`: Flag for returning a `SparseMatrixCSC` instead of a dense matrix. 
+   Setting to `true` requires `SparseArrays` to be loaded. Defaults to `false`.
+
+## Examples
+```jldoctest
+julia> W = lower_triangular(5, 5; sparsity=0.6)
+5×5 Matrix{Float32}:
+ -0.214159   0.0        0.0        0.0       0.0
+  0.710328   0.655184   0.0        0.0       0.0
+ -0.912441   0.311545  -0.412411   0.0       0.0
+  0.0        0.114112   0.551211   0.812451  0.0
+  0.0        0.0       -0.741211   0.914141  0.115412
+
+"""
+
+
+function lower_triangular(rng::AbstractRNG, ::Type{T}, dims::Integer...; 
+                          radius=T(1.0), sparsity=0.9, return_sparse=false) where {T <: Number}
+    
+    throw_sparse_error(return_sparse)
+    check_res_size(dims...)
+    res_size = dims[1]
+    
+    reservoir_matrix = DeviceAgnostic.zeros(rng, T, res_size, res_size)
+    
+    weights = DeviceAgnostic.rand(rng, T, res_size) .* T(2.0) .- T(1.0)
+    self_loop!(rng, reservoir_matrix, weights)
+
+    target_non_zeros = round(Int, res_size * res_size * (1.0 - sparsity))
+    current_non_zeros = res_size # from the self-loops
+    shift = 1
+
+    while current_non_zeros < target_non_zeros && shift < res_size
+        diag_length = res_size - shift
+        remaining_non_zeros = target_non_zeros - current_non_zeros
+        if remaining_non_zeros >= diag_length
+          # Fill the entire diagonal
+          weights = DeviceAgnostic.rand(rng, T, diag_length) .* T(2.0) .- T(1.0)
+          current_non_zeros += diag_length
+        else
+          # We only need a fraction of this diagonal to hit the exact target
+          weights = DeviceAgnostic.zeros(rng, T, diag_length)
+            
+          # Randomly distribute the remaining_non_zeros weights to avoid biasing the top-left
+          active_indices = DeviceAgnostic.randperm(rng, diag_length)[1:remaining_non_zeros]
+          weights[active_indices] = DeviceAgnostic.rand(rng, T, remaining_non_zeros) .* T(2.0) .- T(1.0)
+            
+          current_non_zeros += remaining_non_zeros
+        end
+        
+        delay_line!(rng, reservoir_matrix, weights, shift)
+        shift += 1
+    end
+    
+    scale_radius!(reservoir_matrix, radius)
+    
+    return return_init_as(Val(return_sparse), reservoir_matrix)
+end

--- a/test/test_inits.jl
+++ b/test/test_inits.jl
@@ -24,6 +24,7 @@ reservoir_inits = [
     double_cycle,
     forward_connection,
     low_connectivity,
+    lower_triangular,
     pseudo_svd,
     rand_hyper,
     rand_sparse,
@@ -105,34 +106,4 @@ end
         dl = init(res_size, in_size)
         @test sort(unique(dl)) == Float32.([-0.1, 0.1])
     end
-end
-
-@testset "Lower Triangular Topology Tests" begin
-    
-    # 1. Test Dense Return with Exact Sparsity
-    target_sparsity_1 = 0.8
-    reservoir_dense = lower_triangular(rng, Float16, res_size, res_size; sparsity=target_sparsity_1, return_sparse=false)
-    
-    @test reservoir_dense isa Matrix{Float16}
-    @test size(reservoir_dense) == (res_size, res_size)
-    @test istril(reservoir_dense) == true 
-    
-    expected_non_zeros_1 = round(Int, res_size * res_size * (1.0 - target_sparsity_1))
-    @test count(!iszero, reservoir_dense) == expected_non_zeros_1
-    
-    # 2. Test Sparse Return with a different Exact Sparsity
-    target_sparsity_2 = 0.85
-    reservoir_sparse = lower_triangular(rng, Float32, res_size, res_size; sparsity=target_sparsity_2, return_sparse=true)
-    
-    @test reservoir_sparse isa SparseMatrixCSC{Float32, Int}
-    @test size(reservoir_sparse) == (res_size, res_size)
-    @test istril(reservoir_sparse) == true
-    
-    expected_non_zeros_2 = round(Int, res_size * res_size * (1.0 - target_sparsity_2))
-    @test count(!iszero, reservoir_sparse) == expected_non_zeros_2
-    
-    # 3. Test Scale Radius
-    reservoir_scaled = lower_triangular(rng, Float32, res_size, res_size; radius=2.5)
-    spectral_radius = maximum(abs.(eigvals(reservoir_scaled)))
-    @test spectral_radius ≈ 2.5 atol=1e-5
 end

--- a/test/test_inits.jl
+++ b/test/test_inits.jl
@@ -106,3 +106,33 @@ end
         @test sort(unique(dl)) == Float32.([-0.1, 0.1])
     end
 end
+
+@testset "Lower Triangular Topology Tests" begin
+    
+    # 1. Test Dense Return with Exact Sparsity
+    target_sparsity_1 = 0.8
+    reservoir_dense = lower_triangular(rng, Float16, res_size, res_size; sparsity=target_sparsity_1, return_sparse=false)
+    
+    @test reservoir_dense isa Matrix{Float16}
+    @test size(reservoir_dense) == (res_size, res_size)
+    @test istril(reservoir_dense) == true 
+    
+    expected_non_zeros_1 = round(Int, res_size * res_size * (1.0 - target_sparsity_1))
+    @test count(!iszero, reservoir_dense) == expected_non_zeros_1
+    
+    # 2. Test Sparse Return with a different Exact Sparsity
+    target_sparsity_2 = 0.85
+    reservoir_sparse = lower_triangular(rng, Float32, res_size, res_size; sparsity=target_sparsity_2, return_sparse=true)
+    
+    @test reservoir_sparse isa SparseMatrixCSC{Float32, Int}
+    @test size(reservoir_sparse) == (res_size, res_size)
+    @test istril(reservoir_sparse) == true
+    
+    expected_non_zeros_2 = round(Int, res_size * res_size * (1.0 - target_sparsity_2))
+    @test count(!iszero, reservoir_sparse) == expected_non_zeros_2
+    
+    # 3. Test Scale Radius
+    reservoir_scaled = lower_triangular(rng, Float32, res_size, res_size; radius=2.5)
+    spectral_radius = maximum(abs.(eigvals(reservoir_scaled)))
+    @test spectral_radius ≈ 2.5 atol=1e-5
+end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular  the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context
This addition addresses Issue #268 by implementing the lower triangular sparse topology introduced in [Cossu et al., 2025](https://dl.acm.org/doi/10.1145/3703412.3703413). 

This utilises the generic initialisation building blocks (`self_loop!`, `delay_line!`, etc.) recently merged in #267 to construct the matrices in-place.

### 🚧 Function Implemented
- [x] `lower_triangular`

### 💡 Implementation Notes for `lower_triangular`
**Exact Sparsity:** To maintain strict topological symmetry, the function adds complete diagonals sequentially. To hit the exact user-requested `sparsity` target without spatially biasing the matrix, any remaining weights required for the final partial diagonal are randomly distributed across its indices using `DeviceAgnostic.randperm`.
**Performance:** Implemented Compile-Time Value Dispatch (`Val(return_sparse)`) to ensure type stability when returning `SparseMatrixCSC` vs `Matrix`.
**Testing:** Added full structural coverage using `LinearAlgebra.istril`, alongside exact non-zero counts and spectral radius verification.

