### PR TITLE
Add ResESNCell/ResESN with decoupled alpha/beta skip connections (#417)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReservoirComputing"
 uuid = "7c2d2b1e-3dd4-11ea-355a-8f6a8116e294"
-version = "0.12.18"
+version = "0.12.19"
 authors = ["Francesco Martinuzzi"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ reservoir computing models. More specifically the software offers:
     + [Neuromorphic reservoir computing](https://doi.org/10.1063/5.0282708) `EIESN`/`AdditiveEIESN`
     + [Support vector echo-state machine](https://doi.org/10.1109/TNN.2006.885113) `SVESM`
     + [Local information flow echo state network](https://doi.org/10.1007/s11071-025-10942-6) `LIFESN`
+    + [Residual echo state networks](https://doi.org/10.1016/j.neucom.2024.127966) `ResESN`
     + [Next generation reservoir computing](https://doi.org/10.1038/s41467-021-25801-2) `NGRC`
 - 15+ reservoir initializers and 5+ input layer initializers
 - 5+ reservoir states modification algorithms

--- a/docs/src/api/layers.md
+++ b/docs/src/api/layers.md
@@ -26,6 +26,7 @@
     ES2NCell
     ESNCell
     EuSNCell
+    ResESNCell
     LIFESNCell
 ```
 

--- a/docs/src/api/models.md
+++ b/docs/src/api/models.md
@@ -15,6 +15,7 @@
     StateDelayESN
     SVESM
     LIFESN
+    ResESN
 ```
 
 ## Next generation reservoir computing

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -87,6 +87,7 @@ or `dev` the package.
     + [Neuromorphic reservoir computing](https://doi.org/10.1063/5.0282708)  [`EIESN`](@ref)/[`AdditiveEIESN`](@ref)
     + [Support vector echo-state machine](https://doi.org/10.1109/TNN.2006.885113)  [`SVESM`](@ref)
     + [Local information flow echo state network](https://doi.org/10.1007/s11071-025-10942-6)  [`LIFESN`](@ref)
+    + [Residual echo state networks](https://doi.org/10.1016/j.neucom.2024.127966)  [`ResESN`](@ref)
     + [Next generation reservoir computing](https://doi.org/10.1038/s41467-021-25801-2)  [`NGRC`](@ref)
 - 15+ reservoir initializers and 5+ input layer initializers
 - 5+ reservoir states modification algorithms

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -356,6 +356,18 @@
   month = sep
 }
 
+@article{Ceni2024,
+  title = {Residual echo state networks: Residual recurrent neural networks with stable dynamics and fast learning},
+  ISSN = {0925-2312},
+  url = {http://dx.doi.org/10.1016/j.neucom.2024.127966},
+  DOI = {10.1016/j.neucom.2024.127966},
+  journal = {Neurocomputing},
+  publisher = {Elsevier BV},
+  author = {Ceni,  Andrea and Gallicchio,  Claudio},
+  year = {2024},
+  pages = {127966}
+}
+
 @article{Ceni2025,
   title = {Edge of Stability Echo State Network},
   volume = {36},

--- a/src/ReservoirComputing.jl
+++ b/src/ReservoirComputing.jl
@@ -27,6 +27,7 @@ include("layers/esn_cell.jl")
 include("layers/additive_eiesn_cell.jl")
 include("layers/eiesn_cell.jl")
 include("layers/es2n_cell.jl")
+include("layers/resesn_cell.jl")
 include("layers/eusn_cell.jl")
 include("layers/svmreadout.jl")
 include("layers/lif_wrapper.jl")
@@ -44,6 +45,7 @@ include("models/esn.jl")
 include("models/additive_eiesn.jl")
 include("models/eiesn.jl")
 include("models/es2n.jl")
+include("models/resesn.jl")
 include("models/esn_deep.jl")
 include("models/esn_delay.jl")
 include("models/esn_hybrid.jl")
@@ -55,7 +57,7 @@ include("models/ngrc.jl")
 include("extensions/reca.jl")
 
 export ReservoirComputer
-export AdditiveEIESNCell, EIESNCell, ES2NCell, ESNCell, EuSNCell, LIFESNCell
+export AdditiveEIESNCell, EIESNCell, ES2NCell, ESNCell, EuSNCell, LIFESNCell, ResESNCell
 export Collect, collectstates, DelayLayer, LinearReadout, NonlinearFeaturesLayer,
     ReservoirChain, StatefulLayer
 export SVMReadout
@@ -71,7 +73,7 @@ export block_diagonal, chaotic_init, cycle_jumps, delay_line, delayline_backward
 export add_jumps!, backward_connection!, delay_line!, permute_matrix!, reverse_simple_cycle!,
     scale_radius!, self_loop!, simple_cycle!
 export polynomial_monomials, chebyshev_monomials, predict, QRSolver, resetcarry!, train, train!
-export AdditiveEIESN, DeepESN, DelayESN, EIESN, ES2N, ESN, EuSN, HybridESN, InputDelayESN, LIFESN, StateDelayESN, SVESM
+export AdditiveEIESN, DeepESN, DelayESN, EIESN, ES2N, ESN, EuSN, HybridESN, InputDelayESN, LIFESN, ResESN, StateDelayESN, SVESM
 export NGRC
 #ext
 export RECACell, RECA

--- a/src/layers/resesn_cell.jl
+++ b/src/layers/resesn_cell.jl
@@ -1,0 +1,137 @@
+@doc raw"""
+    ResESNCell(in_dims => out_dims, [activation];
+        use_bias=False(), init_bias=zeros32,
+        init_reservoir=rand_sparse, init_input=scaled_rand,
+        init_state=randn32, init_orthogonal=orthogonal,
+        alpha=1.0, beta=1.0)
+
+Residual Echo State Network (ResESN) cell [Ceni2024](@cite).
+
+Unlike [`ES2NCell`](@ref), where the skip and nonlinear weights are coupled as
+`(1-β)` and `β`, ResESN decouples them into two independent scalars `α` and `β`.
+
+## Equations
+
+```math
+\begin{aligned}
+    \mathbf{x}(t) &= \alpha\, \mathbf{O}\, \mathbf{x}(t-1) +
+        \beta\, \phi\!\left(\mathbf{W}_{\text{in}} \mathbf{u}(t) +
+        \mathbf{W}_r \mathbf{x}(t-1) + \mathbf{b} \right)
+\end{aligned}
+```
+
+## Arguments
+
+    - `in_dims`: Input dimension.
+    - `out_dims`: Reservoir (hidden state) dimension.
+    - `activation`: Activation function. Default: `tanh_fast`.
+
+## Keyword arguments
+
+  - `use_bias`: Whether to include a bias term. Default: `false`.
+  - `init_bias`: Initializer for the bias. Used only if `use_bias=true`.
+    Default is `zeros32`.
+  - `init_reservoir`: Initializer for the reservoir matrix `W_res`.
+    Default is [`rand_sparse`](@ref).
+  - `init_orthogonal`: Initializer for the orthogonal matrix `O`.
+    Default is `orthogonal`.
+  - `init_input`: Initializer for the input matrix `W_in`.
+    Default is [`scaled_rand`](@ref).
+  - `init_state`: Initializer for the hidden state when an external
+    state is not provided. Default is `randn32`.
+  - `alpha`: Residual skip weight `α`. Default: `1.0`.
+  - `beta`: Nonlinear transform weight `β`. Default: `1.0`.
+
+## Inputs
+
+  - **Case 1:** `x :: AbstractArray (in_dims, batch)`
+    A fresh state is created via `init_state`; the call is forwarded to Case 2.
+  - **Case 2:** `(x, (h,))` where `h :: AbstractArray (out_dims, batch)`
+    Computes the update and returns the new state.
+
+In both cases, the forward returns `((h_new, (h_new,)), st_out)` where `st_out`
+contains any updated internal state.
+
+## Returns
+
+  - Output/hidden state `h_new :: out_dims` and state tuple `(h_new,)`.
+  - Updated layer state (NamedTuple).
+
+## Parameters
+
+  - `input_matrix :: (out_dims × in_dims)` — `W_in`
+  - `reservoir_matrix :: (out_dims × out_dims)` — `W_res`
+  - `orthogonal_matrix :: (out_dims × out_dims)` — `O`
+  - `bias :: (out_dims,)` — present only if `use_bias=true`
+
+## States
+
+Created by `initialstates(rng, esn)`:
+
+  - `rng`: a replicated RNG used to sample initial hidden states when needed.
+"""
+@concrete struct ResESNCell <: AbstractEchoStateNetworkCell
+    activation
+    in_dims <: IntegerType
+    out_dims <: IntegerType
+    init_bias
+    init_reservoir
+    init_input
+    init_orthogonal
+    init_state
+    alpha
+    beta
+    use_bias <: StaticBool
+end
+
+function ResESNCell(
+        (in_dims, out_dims)::Pair{<:IntegerType, <:IntegerType},
+        activation = tanh_fast; use_bias::BoolType = False(), init_bias = zeros32,
+        init_reservoir = rand_sparse, init_input = scaled_rand,
+        init_state = randn32, init_orthogonal = orthogonal,
+        alpha::AbstractFloat = 1.0, beta::AbstractFloat = 1.0
+    )
+    return ResESNCell(
+        activation, in_dims, out_dims, init_bias, init_reservoir,
+        init_input, init_orthogonal, init_state, alpha, beta, static(use_bias)
+    )
+end
+
+function initialparameters(rng::AbstractRNG, esn::ResESNCell)
+    ps = (
+        input_matrix = esn.init_input(rng, esn.out_dims, esn.in_dims),
+        reservoir_matrix = esn.init_reservoir(rng, esn.out_dims, esn.out_dims),
+        orthogonal_matrix = esn.init_orthogonal(rng, esn.out_dims, esn.out_dims),
+    )
+    if has_bias(esn)
+        ps = merge(ps, (bias = esn.init_bias(rng, esn.out_dims),))
+    end
+    return ps
+end
+
+function (esn::ResESNCell)((inp, (hidden_state,))::InputType, ps, st::NamedTuple)
+    T = eltype(inp)
+    bias = safe_getproperty(ps, Val(:bias))
+    t_alpha = T(esn.alpha)
+    t_beta = T(esn.beta)
+    win_inp = dense_bias(ps.input_matrix, inp, nothing)
+    w_state = dense_bias(ps.reservoir_matrix, hidden_state, bias)
+    candidate_h = esn.activation.(win_inp .+ w_state)
+    # Parenthesise the matmul so we scale the O(n) result vector,
+    # not the O(n²) matrix — avoids a full-matrix temporary.
+    h_new = t_alpha .* (ps.orthogonal_matrix * hidden_state) .+
+        t_beta .* candidate_h
+    return (h_new, (h_new,)), st
+end
+
+function Base.show(io::IO, esn::ResESNCell)
+    print(io, "ResESNCell($(esn.in_dims) => $(esn.out_dims)")
+    if esn.alpha != eltype(esn.alpha)(1.0)
+        print(io, ", alpha=$(esn.alpha)")
+    end
+    if esn.beta != eltype(esn.beta)(1.0)
+        print(io, ", beta=$(esn.beta)")
+    end
+    has_bias(esn) || print(io, ", use_bias=false")
+    return print(io, ")")
+end

--- a/src/models/resesn.jl
+++ b/src/models/resesn.jl
@@ -1,0 +1,129 @@
+@doc raw"""
+    ResESN(in_dims, res_dims, out_dims, activation=tanh;
+        alpha=1.0, beta=1.0, init_reservoir=rand_sparse, init_input=scaled_rand,
+        init_bias=zeros32, init_state=randn32, use_bias=False(),
+        state_modifiers=(), readout_activation=identity,
+        init_orthogonal=orthogonal)
+
+Residual Echo State Network (ResESN) [Ceni2024](@cite).
+
+Unlike [`ES2N`](@ref), where the skip and nonlinear weights are coupled as
+`(1-β)` and `β`, ResESN decouples them into two independent scalars `α` and `β`.
+
+## Equations
+
+```math
+\begin{aligned}
+    \mathbf{x}(t) &= \alpha\, \mathbf{O}\, \mathbf{x}(t-1) +
+        \beta\, \phi\!\left(\mathbf{W}_{\text{in}} \mathbf{u}(t)
+        + \mathbf{W}_r \mathbf{x}(t-1) + \mathbf{b} \right) \\
+    \mathbf{z}(t) &= \mathrm{Mods}\!\left(\mathbf{x}(t)\right) \\
+    \mathbf{y}(t) &= \rho\!\left(
+        \mathbf{W}_{\text{out}}\, \mathbf{z}(t)
+        + \mathbf{b}_{\text{out}} \right)
+\end{aligned}
+```
+
+## Arguments
+
+  - `in_dims`: Input dimension.
+  - `res_dims`: Reservoir (hidden state) dimension.
+  - `out_dims`: Output dimension.
+  - `activation`: Reservoir activation (for [`ResESNCell`](@ref)). Default: `tanh`.
+
+## Keyword arguments
+
+  - `alpha`: Residual skip weight `α`. Default: `1.0`.
+  - `beta`: Nonlinear transform weight `β`. Default: `1.0`.
+  - `init_reservoir`: Initializer for `W_res`. Default: [`rand_sparse`](@ref).
+  - `init_input`: Initializer for `W_in`. Default: [`scaled_rand`](@ref).
+  - `init_orthogonal`: Initializer for `O`. Default: `orthogonal`.
+  - `init_bias`: Initializer for reservoir bias (used if `use_bias=true`).
+    Default: `zeros32`.
+  - `init_state`: Initializer used when an external state is not provided.
+    Default: `randn32`.
+  - `use_bias`: Whether the reservoir uses a bias term. Default: `false`.
+  - `state_modifiers`: A layer or collection of layers applied to the reservoir
+    state before the readout. Accepts a single layer, an `AbstractVector`, or a
+    `Tuple`. Default: empty `()`.
+  - `readout_activation`: Activation for the linear readout. Default: `identity`.
+
+## Inputs
+
+  - `x :: AbstractArray (in_dims, batch)`
+
+## Returns
+
+  - Output `y :: (out_dims, batch)`.
+  - Updated layer state (NamedTuple).
+
+## Parameters
+
+  - `reservoir` — parameters of the internal [`ResESNCell`](@ref), including:
+      - `input_matrix :: (res_dims × in_dims)` — `W_in`
+      - `reservoir_matrix :: (res_dims × res_dims)` — `W_res`
+      - `orthogonal_matrix :: (res_dims × res_dims)` — `O`
+      - `bias :: (res_dims,)` — present only if `use_bias=true`
+  - `states_modifiers` — a `Tuple` with parameters for each modifier layer (may be empty).
+  - `readout` — parameters of [`LinearReadout`](@ref), typically:
+      - `weight :: (out_dims × res_dims)` — `W_out`
+      - `bias :: (out_dims,)` — `b_out` (if the readout uses bias)
+
+> Exact field names for modifiers/readout follow their respective layer
+> definitions.
+
+## States
+
+  - `reservoir` — states for the internal [`ResESNCell`](@ref) (e.g. `rng` used to sample initial hidden states).
+  - `states_modifiers` — a `Tuple` with states for each modifier layer.
+  - `readout` — states for [`LinearReadout`](@ref).
+
+"""
+@concrete struct ResESN <:
+    AbstractEchoStateNetwork{(:reservoir, :states_modifiers, :readout)}
+    reservoir
+    states_modifiers
+    readout
+end
+
+function ResESN(
+        in_dims::IntegerType, res_dims::IntegerType,
+        out_dims::IntegerType, activation = tanh;
+        readout_activation = identity,
+        state_modifiers = (),
+        kwargs...
+    )
+    cell = StatefulLayer(ResESNCell(in_dims => res_dims, activation; kwargs...))
+    mods_tuple = state_modifiers isa Tuple || state_modifiers isa AbstractVector ?
+        Tuple(state_modifiers) : (state_modifiers,)
+    mods = _wrap_layers(mods_tuple)
+    ro = LinearReadout(res_dims => out_dims, readout_activation)
+    return ResESN(cell, mods, ro)
+end
+
+function Base.show(io::IO, esn::ResESN)
+    print(io, "ResESN(\n")
+
+    print(io, "    reservoir = ")
+    show(io, esn.reservoir)
+    print(io, ",\n")
+
+    print(io, "    state_modifiers = ")
+    if isempty(esn.states_modifiers)
+        print(io, "()")
+    else
+        print(io, "(")
+        for (i, m) in enumerate(esn.states_modifiers)
+            i > 1 && print(io, ", ")
+            show(io, m)
+        end
+        print(io, ")")
+    end
+    print(io, ",\n")
+
+    print(io, "    readout = ")
+    show(io, esn.readout)
+    print(io, "\n)")
+
+    return
+end

--- a/test/layers/test_esncell.jl
+++ b/test/layers/test_esncell.jl
@@ -19,18 +19,22 @@ cell_name(::Type{C}) where {C} = string(nameof(C))
 mix_kw(::Type{ESNCell}) = :leak_coefficient
 mix_kw(::Type{ES2NCell}) = :proximity
 mix_kw(::Type{EuSNCell}) = :leak_coefficient
+mix_kw(::Type{ResESNCell}) = :beta
 
 mix_label(::Type{ESNCell}) = "leak_coefficient"
 mix_label(::Type{ES2NCell}) = "proximity"
 mix_label(::Type{EuSNCell}) = "leak_coefficient"
+mix_label(::Type{ResESNCell}) = "beta"
 
 default_extra_ctor_kwargs(::Type{ESNCell}) = NamedTuple()
 default_extra_ctor_kwargs(::Type{ES2NCell}) = (init_orthogonal = _W_I,)
 default_extra_ctor_kwargs(::Type{EuSNCell}) = NamedTuple()  # diffusion exists but we leave default unless overridden
+default_extra_ctor_kwargs(::Type{ResESNCell}) = (init_orthogonal = _W_I, alpha = 1.0)
 
 extra_param_keys(::Type{ESNCell}) = ()
 extra_param_keys(::Type{ES2NCell}) = (:orthogonal_matrix,)
 extra_param_keys(::Type{EuSNCell}) = ()
+extra_param_keys(::Type{ResESNCell}) = (:orthogonal_matrix,)
 
 function build_cell(
         ::Type{C}, in_dims::Integer, out_dims::Integer;
@@ -261,7 +265,40 @@ function test_echo_state_cell_contract(::Type{C}) where {C}
 end
 
 @testset "AbstractEchoStateNetworkCell contract" begin
-    for C in (ESNCell, ES2NCell, EuSNCell)
+    for C in (ESNCell, ES2NCell, EuSNCell, ResESNCell)
         test_echo_state_cell_contract(C)
+    end
+end
+
+@testset "ResESNCell: decoupled alpha/beta" begin
+    cell = ResESNCell(
+        3 => 3, identity;
+        use_bias = False(),
+        init_input = _W_I,
+        init_reservoir = _W_ZZ,
+        init_orthogonal = _W_I,
+        init_state = _Z32,
+        alpha = 0.4,
+        beta = 0.7
+    )
+
+    ps = initialparameters(MersenneTwister(0), cell)
+    # Non-collinear vectors so the system alpha=1-p, beta=p is fully determined.
+    # Any ES2N proximity p forces (1-p)+p=1; since 0.4+0.7=1.1≠1, no p exists.
+    x = Float32[1, 0, 2]
+    h0 = Float32[0, 3, 1]
+
+    (y_tuple, _) = cell((x, (h0,)), ps, NamedTuple())
+    y, _ = y_tuple
+
+    # h = alpha * I * h0 + beta * identity(I*x + 0*h0)
+    #   = 0.4 * h0 + 0.7 * x
+    @test y ≈ 0.4f0 .* h0 .+ 0.7f0 .* x
+
+    # No single ES2N proximity p can reproduce this result:
+    # matching requires alpha=1-p AND beta=p simultaneously → alpha+beta=1.
+    @testset "unreachable by ES2N proximity p=$p" for p in 0.0f0:0.05f0:1.0f0
+        es2n_result = (1.0f0 - p) .* h0 .+ p .* x
+        @test !(y ≈ es2n_result)
     end
 end

--- a/test/models/test_esn.jl
+++ b/test/models/test_esn.jl
@@ -26,14 +26,17 @@ model_name(::Type{M}) where {M} = string(nameof(M))
 mix_kw(::Type{ESN}) = :leak_coefficient
 mix_kw(::Type{ES2N}) = :proximity
 mix_kw(::Type{EuSN}) = :leak_coefficient
+mix_kw(::Type{ResESN}) = :beta
 
 reservoir_param_keys(::Type{ESN}) = (:input_matrix, :reservoir_matrix)
 reservoir_param_keys(::Type{ES2N}) = (:input_matrix, :reservoir_matrix, :orthogonal_matrix)
 reservoir_param_keys(::Type{EuSN}) = (:input_matrix, :reservoir_matrix)
+reservoir_param_keys(::Type{ResESN}) = (:input_matrix, :reservoir_matrix, :orthogonal_matrix)
 
 default_reservoir_kwargs(::Type{ESN}) = NamedTuple()
 default_reservoir_kwargs(::Type{ES2N}) = (init_orthogonal = _W_I,)
 default_reservoir_kwargs(::Type{EuSN}) = NamedTuple()
+default_reservoir_kwargs(::Type{ResESN}) = (init_orthogonal = _W_I, alpha = 1.0)
 
 function build_model(
         ::Type{M}, in_dims::Int, res_dims::Int, out_dims::Int, activation;
@@ -253,7 +256,7 @@ function test_esn_family_contract(::Type{M}) where {M}
 end
 
 @testset "ESN-family model contract" begin
-    for M in (ESN, ES2N, EuSN)
+    for M in (ESN, ES2N, EuSN, ResESN)
         test_esn_family_contract(M)
     end
 end


### PR DESCRIPTION
Closes #417 

Implements Ceni & Gallicchio (Neurocomputing 2024, doi:10.1016/j.neucom.2024.127966). Unlike ES2N which couples skip and nonlinear weights as (1-β) and β, ResESN uses independent α (skip) and β (nonlinear) scalars:

  h(t) = α·O·h(t-1) + β·φ(W_in·u(t) + W_r·h(t-1) + b)

Forward pass parenthesises the orthogonal matmul (α .* (O * h)) to scale the O(n) result vector rather than the O(n²) matrix, avoiding a full-matrix temporary that ES2NCell currently incurs.

Cell and model plug into existing parametric test harnesses; dedicated test verifies α+β≠1 produces results unreachable by any single ES2N proximity value.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
