### PR TITLE
fix: remove :states injection from train! state (#437)

### DIFF
--- a/src/train.jl
+++ b/src/train.jl
@@ -105,8 +105,8 @@ end
 
 Trains a given reservoir computing by creating the reservoir states from `train_data`,
 and then fiting the readout layer using `target_data` as target.
-The learned weights/layer are written into `ps`, while the reservoir states are written
-in `st`.
+The learned weights/layer are written into `ps`. Use `return_states=true` to also
+obtain the feature matrix used for the fit, or call [`collectstates`](@ref) directly.
 
 ## Arguments
 
@@ -151,7 +151,6 @@ function train!(
         (raw_states, target_data)
     output_matrix = train(train_method, states_wo, traindata_wo; kwargs...)
     ps2, st_after = addreadout!(rc, output_matrix, ps, st_after)
-    st_after = merge(st_after, (; :states => states_wo))
     return return_states ? ((ps2, st_after), states_wo) : (ps2, st_after)
 end
 


### PR DESCRIPTION
## Summary

- Removes the `merge(st_after, (; :states => states_wo))` line introduced in c29cdad4 from `train!`.
- Updates the `train!` docstring to point users to `return_states=true` / `collectstates` for accessing the feature matrix.

## Motivation

`ReservoirChain`'s `applychain` is `@generated` and dispatches only when `ps::NamedTuple{fields}` and `st::NamedTuple{fields}` share the same `fields`. The `:states` injection added an extra top-level key to `st`, so any forward or `predict` call following `train!` failed with a `MethodError` (reported in #437). The injection also broke the Lux convention that `st` mirrors the layer structure, and was already redundant with the existing `return_states=true` keyword.

This PR addresses the failure side of the issue. Broader `ReservoirChain` test coverage (a `setup → train! → forward → predict` roundtrip) will follow in a separate PR.

## Test plan

- [x] Existing test suite passes (`Pkg.test()` — Layers, Echo State Networks, NGRC, LIFESN, SVESM, etc.).
- [x] The MWE from #437 now runs end-to-end without a `MethodError`.

Closes #437