### PR TITLE
 docs: add reservoir memory networks to readme and docs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ reservoir computing models. More specifically the software offers:
     + [Local information flow echo state network](https://doi.org/10.1007/s11071-025-10942-6) `LIFESN`
     + [Residual echo state networks](https://doi.org/10.1016/j.neucom.2024.127966) `ResESN`
     + [Next generation reservoir computing](https://doi.org/10.1038/s41467-021-25801-2) `NGRC`
-    + [Reservoir memory networks](https://doi.org/10.14428/ESANN/2024.ES2024-117) `RMN`
+    + [Reservoir memory networks](https://doi.org/10.14428/ESANN/2024.ES2024-117) `RMNCell`/`RMNESN` / `RMNResESN`
 - 20+ reservoir initializers and 5+ input layer initializers
 - 5+ reservoir states modification algorithms
 - Sparse matrix computation through

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ reservoir computing models. More specifically the software offers:
     + [Local information flow echo state network](https://doi.org/10.1007/s11071-025-10942-6) `LIFESN`
     + [Residual echo state networks](https://doi.org/10.1016/j.neucom.2024.127966) `ResESN`
     + [Next generation reservoir computing](https://doi.org/10.1038/s41467-021-25801-2) `NGRC`
+    + [Reservoir memory networks](https://doi.org/10.14428/ESANN/2024.ES2024-117) `RMN`
 - 20+ reservoir initializers and 5+ input layer initializers
 - 5+ reservoir states modification algorithms
 - Sparse matrix computation through

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -89,6 +89,7 @@ or `dev` the package.
     + [Local information flow echo state network](https://doi.org/10.1007/s11071-025-10942-6)  [`LIFESN`](@ref)
     + [Residual echo state networks](https://doi.org/10.1016/j.neucom.2024.127966)  [`ResESN`](@ref)
     + [Next generation reservoir computing](https://doi.org/10.1038/s41467-021-25801-2)  [`NGRC`](@ref)
+    + [Reservoir memory networks](https://doi.org/10.14428/ESANN/2024.ES2024-117) [`RMN`](@ref)
 - 20+ reservoir initializers and 5+ input layer initializers
 - 5+ reservoir states modification algorithms
 - Sparse matrix computation through

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -89,7 +89,7 @@ or `dev` the package.
     + [Local information flow echo state network](https://doi.org/10.1007/s11071-025-10942-6)  [`LIFESN`](@ref)
     + [Residual echo state networks](https://doi.org/10.1016/j.neucom.2024.127966)  [`ResESN`](@ref)
     + [Next generation reservoir computing](https://doi.org/10.1038/s41467-021-25801-2)  [`NGRC`](@ref)
-    + [Reservoir memory networks](https://doi.org/10.14428/ESANN/2024.ES2024-117) [`RMN`](@ref)
+    + [Reservoir memory networks](https://doi.org/10.14428/ESANN/2024.ES2024-117) [`RMNCell`](@ref)/[`RMNESN`](@ref)/[`RMNResESN`](@ref)
 - 20+ reservoir initializers and 5+ input layer initializers
 - 5+ reservoir states modification algorithms
 - Sparse matrix computation through


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
