### PR TITLE
Re-enable downgrade CI

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,7 +12,6 @@ on:
       - "docs/**"
 jobs:
   test:
-    if: false  # Disabled: waiting on dependency updates. See issue #359 for details.
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -32,6 +31,6 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:
-          ALLOW_RERESOLVE: false
+          allow_reresolve: true
         env:
           GROUP: ${{ matrix.group }}


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Draft.

Re-enables the downgrade workflow (was disabled). The julia-actions/julia-downgrade-compat tooling problems that affected SciML monorepos are fixed and released in `@v2`; this package builds and passes its full test suite against the downgraded (minimal compatible) dependency versions. The runtest step uses `allow_reresolve: true` so the test environment can resolve transitive/test-only dependencies that the downgrade step does not lock.

Verified locally on Julia 1.11: downgrade resolve + build + `Pkg.test` all pass at downgraded versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)