### PR TITLE
docs: document continuous-time reservoir types to fix missing_docs build failure

### DIFF
--- a/docs/src/api/layers.md
+++ b/docs/src/api/layers.md
@@ -36,6 +36,15 @@
     LIFESNCell
 ```
 
+## Continuous-time reservoirs
+
+```@docs
+    AbstractSciMLProblemReservoir
+    SciMLProblemReservoir
+    AbstractSampler
+    TerminalStateSampling
+```
+
 ## Wrappers
 
 ```@docs


### PR DESCRIPTION
## Problem

The master Documentation CI is failing with a Documenter `:missing_docs` error:

```
┌ Error: 4 docstrings not included in the manual:
│     ReservoirComputing.SciMLProblemReservoir
│     ReservoirComputing.AbstractSampler
│     ReservoirComputing.AbstractSciMLProblemReservoir
│     ReservoirComputing.TerminalStateSampling
ERROR: LoadError: `makedocs` encountered an error [:missing_docs]
```

These four exported types were added in #446 (`add-sciml-problem-reservoir`) with docstrings, but were never referenced in any `@docs`/`@autodocs` block. Because `docs/make.jl` runs `makedocs(; modules = [ReservoirComputing], ...)`, every documented export must appear in the manual, so the build errors out.

## Fix

Add a "Continuous-time reservoirs" section to `docs/src/api/layers.md` that documents all four symbols (`AbstractSciMLProblemReservoir`, `SciMLProblemReservoir`, `AbstractSampler`, `TerminalStateSampling`). These are reservoir layer / sampler types, so the Layers API page is the natural home.

## Local verification

Ran the full docs build locally on Julia 1.10 (the package's `[compat]` julia floor):

```
julia +1.10 --project=docs docs/make.jl
```

It now completes with exit code 0; `CheckDocument` and `RenderDocument` both pass and there is no `:missing_docs` error. The only remaining output is benign size-threshold warnings (pre-existing) and the expected "Skipping deployment" notice when run outside CI.

Please ignore until reviewed by @ChrisRackauckas.
