### PR TITLE
docs: include SciMLProblemReservoir docstrings in the manual

### DIFF
--- a/docs/src/api/layers.md
+++ b/docs/src/api/layers.md
@@ -36,6 +36,18 @@
     LIFESNCell
 ```
 
+## Continuous-time reservoirs
+
+```@docs
+    AbstractSciMLProblemReservoir
+    SciMLProblemReservoir
+```
+
+```@docs
+    AbstractSampler
+    TerminalStateSampling
+```
+
 ## Wrappers
 
 ```@docs


### PR DESCRIPTION
The master Documentation CI check is failing. Documenter's `missing_docs` check terminates `makedocs` because four exported, docstring-carrying types in `src/layers/sciml_reservoir.jl` are not referenced in any `@docs`/`@autodocs` block:

- `ReservoirComputing.AbstractSciMLProblemReservoir`
- `ReservoirComputing.SciMLProblemReservoir`
- `ReservoirComputing.AbstractSampler`
- `ReservoirComputing.TerminalStateSampling`

## Fix

Add a "Continuous-time reservoirs" section to `docs/src/api/layers.md` (these are Lux layer / sampler types, so the Layers API page is the natural home) that includes the four docstrings.

## Local verification

Built the docs locally on Julia 1.12.6 (the CI `1` channel) with `julia --project=docs docs/make.jl`:

- `CheckDocument: running document checks.` now passes (no `missing_docs` error)
- `RenderDocument` / `HTMLWriter` complete; build exits 0
- Confirmed all four symbols render with proper docstring anchors in `docs/build/api/layers/index.html`

Only remaining log lines are benign warnings that predate this change (models page over the 100 KiB `size_threshold_warn`, well under the 200 KiB hard limit; "Skipping deployment" which is expected for a local run).

Please ignore until reviewed by @ChrisRackauckas