### PR TITLE
Bump version to 0.12.27

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReservoirComputing"
 uuid = "7c2d2b1e-3dd4-11ea-355a-8f6a8116e294"
-version = "0.12.26"
+version = "0.12.27"
 authors = ["Francesco Martinuzzi"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (0.12.26 -> 0.12.27) to release unreleased commits on `master` via JuliaRegistrator.