### PR TITLE
Release prep: bump ReservoirComputing to 0.12.28

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReservoirComputing"
 uuid = "7c2d2b1e-3dd4-11ea-355a-8f6a8116e294"
-version = "0.12.27"
+version = "0.12.28"
 authors = ["Francesco Martinuzzi"]
 
 [deps]


### PR DESCRIPTION
Patch release for the accumulated docstring/QA/test scaffolding changes since v0.12.27.