### PR TITLE
Bump ReservoirComputing to v0.12.29 for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReservoirComputing"
 uuid = "7c2d2b1e-3dd4-11ea-355a-8f6a8116e294"
-version = "0.12.28"
+version = "0.12.29"
 authors = ["Francesco Martinuzzi"]
 
 [deps]


### PR DESCRIPTION
Bumps `ReservoirComputing` 0.12.28 → 0.12.29 so the unreleased bug fix on master gets registered.

Unreleased since v0.12.28:
- 9b34d618 — fix: preserve array backend in `collectstates`

## Verification
Detected by comparing the `git-tree-sha1` of the latest registered version in the General registry against the `src` tree on `master`: they differ, so the code above is on master but not in any released version.

**No test suite was run locally for this PR** — it changes only the `version` field in `Project.toml` and adds no code. CI on this PR is the check that matters.

Please ignore until reviewed by @ChrisRackauckas.