### PR TITLE
fix(train): reject square-only LinearSolve ridge solvers

### DIFF
--- a/src/ReservoirComputing.jl
+++ b/src/ReservoirComputing.jl
@@ -3,7 +3,8 @@ module ReservoirComputing
 using ArrayInterface: ArrayInterface
 using ConcreteStructs: @concrete
 using LinearAlgebra: eigvals, I, qr, Diagonal, diag, mul!, Symmetric, norm
-using LinearSolve: LinearProblem, solve, SciMLLinearSolveAlgorithm
+using LinearSolve: LinearProblem, solve, SciMLLinearSolveAlgorithm, needs_square_A,
+    SVDFactorization
 using LinearSolve: QRFactorization as LinearSolveQRFactorization
 using LuxCore: AbstractLuxLayer, AbstractLuxContainerLayer, AbstractLuxWrapperLayer,
     setup, apply, replicate

--- a/src/train.jl
+++ b/src/train.jl
@@ -165,8 +165,8 @@ function _train_ridge(
                 "augmented system is always rectangular (more rows than features). " *
                 "Use QRFactorization(), SVDFactorization(), or NormalCholeskyFactorization() " *
                 "instead."
-            )
         )
+    )
     solution = solve(LinearProblem(design, rhs), solver; kwargs...)
     return Matrix(solution.u')
 end

--- a/src/train.jl
+++ b/src/train.jl
@@ -125,6 +125,9 @@ function _ridge_augmented_system(
             "states has $n_samples samples, targets has $n_target_samples"
         )
     )
+    n_samples > 0 || throw(
+        ArgumentError("ridge regression requires at least one training sample")
+    )
 
     n_features = size(states, 1)
     n_outputs = size(targets, 1)
@@ -148,11 +151,22 @@ function _train_ridge(
     return Matrix(weight_transpose')
 end
 
+_ridge_solver_supported(solver::SciMLLinearSolveAlgorithm) = !needs_square_A(solver)
+_ridge_solver_supported(::SVDFactorization) = true
+
 function _train_ridge(
         solver::SciMLLinearSolveAlgorithm, objective::RidgeRegression,
         states::AbstractMatrix, targets::AbstractMatrix; kwargs...
     )
     design, rhs = _ridge_augmented_system(objective, states, targets)
+    _ridge_solver_supported(solver) || throw(
+        ArgumentError(
+            "solver $(typeof(solver)) requires a square matrix, but ridge regression's " *
+                "augmented system is always rectangular (more rows than features). " *
+                "Use QRFactorization(), SVDFactorization(), or NormalCholeskyFactorization() " *
+                "instead."
+            )
+        )
     solution = solve(LinearProblem(design, rhs), solver; kwargs...)
     return Matrix(solution.u')
 end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,9 +1,21 @@
 using SciMLTesting, ReservoirComputing, Test
 using JET
 
+# names re-exported wholesale from WeightInitializers/LuxCore via `@reexport`
+const _REEXPORTED_NAMES = (
+    :WeightInitializers, :apply, :glorot_normal, :glorot_uniform, :identity_init,
+    :initialparameters, :initialstates, :kaiming_normal, :kaiming_uniform,
+    :ones16, :ones32, :ones64, :onesC16, :onesC32, :onesC64, :orthogonal,
+    :rand16, :rand32, :rand64, :randC16, :randC32, :randC64,
+    :randn16, :randn32, :randn64, :randnC16, :randnC32, :randnC64,
+    :setup, :sparse_init, :truncated_normal, :zeros16, :zeros32, :zeros64,
+    :zerosC16, :zerosC32, :zerosC64,
+)
+
 run_qa(
     ReservoirComputing;
     explicit_imports = true,
+    reexports_allow = (_REEXPORTED_NAMES..., :QRFactorization),  # QRFactorization aliases LinearSolve's
     jet_kwargs = (;
         target_modules = (ReservoirComputing,),
         mode = :typo,
@@ -12,13 +24,7 @@ run_qa(
     api_docs_kwargs = (;
         rendered = true,
         rendered_ignore = (
-            :WeightInitializers, :apply, :glorot_normal, :glorot_uniform, :identity_init,
-            :initialparameters, :initialstates, :kaiming_normal, :kaiming_uniform,
-            :ones16, :ones32, :ones64, :onesC16, :onesC32, :onesC64, :orthogonal,
-            :rand16, :rand32, :rand64, :randC16, :randC32, :randC64,
-            :randn16, :randn32, :randn64, :randnC16, :randnC32, :randnC64,
-            :setup, :sparse_init, :truncated_normal, :zeros16, :zeros32, :zeros64,
-            :zerosC16, :zerosC32, :zerosC64,
+            _REEXPORTED_NAMES...,
             :StandardRidge,  # deprecated alias of RidgeRegression
         ),
     ),

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -51,6 +51,7 @@ run_qa(
                 :setup,              # LuxCore (non-public)
                 :statelength,        # LuxCore (non-public)
                 :SciMLLinearSolveAlgorithm,  # LinearSolve (non-public abstract type)
+                :needs_square_A,     # LinearSolve (non-public)
             ),
         ),
     )

--- a/test/test_train_ridge.jl
+++ b/test/test_train_ridge.jl
@@ -223,12 +223,41 @@ end
     )
 end
 
+@testset "train(RidgeRegression): empty training data rejected" begin
+    states = Matrix{Float64}(undef, 4, 0)
+    targets = Matrix{Float64}(undef, 2, 0)
+    for solver in (QRSolver(), QRFactorization(), LUFactorization())
+        err = try
+            train(RidgeRegression(1.0e-3), states, targets; solver = solver)
+            nothing
+        catch caught
+            caught
+        end
+        @test err isa ArgumentError
+        @test occursin("at least one training sample", sprint(showerror, err))
+    end
+end
+
 @testset "train(RidgeRegression): unsupported solver" begin
     states = randn(Float64, 4, 20)
     targets = randn(Float64, 2, 20)
     @test_throws ArgumentError train(
         RidgeRegression(1.0e-3), states, targets; solver = :not_a_solver
     )
+end
+
+@testset "train(RidgeRegression): square-only LinearSolve algorithm errors clearly" begin
+    states = randn(Float64, 4, 20)
+    targets = randn(Float64, 2, 20)
+    @test_throws ArgumentError train(
+        RidgeRegression(1.0e-3), states, targets; solver = LUFactorization()
+    )
+    try
+        train(RidgeRegression(1.0e-3), states, targets; solver = LUFactorization())
+    catch err
+        @test occursin("QRFactorization", err.msg)
+        @test occursin("square", err.msg)
+    end
 end
 
 @testset "train(RidgeRegression): negative regularization rejected" begin


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
