### PR TITLE
Raise OrdinaryDiffEqLowOrderRK floor to 2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -46,7 +46,7 @@ NNlib = "0.9.30"
 OrdinaryDiffEq = "6, 7"
 # Cap below 4.14: LowOrderRK 2.2.x requires OrdinaryDiffEqCore.u_cache.
 OrdinaryDiffEqCore = "4.10 - 4.13"
-OrdinaryDiffEqLowOrderRK = "1.2, 2"
+OrdinaryDiffEqLowOrderRK = "2"
 PrecompileTools = "1.2"
 Random = "1.10"
 SafeTestsets = "0.1"


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed

Pure `[compat]` lower-bound bump for a test extra:

- `OrdinaryDiffEqLowOrderRK = "1.2, 2"` → `"2"`

No library code, tests, or package version were changed.

## Why

`OrdinaryDiffEqLowOrderRK = "1.2, 2"` allows 1.2.0. That version is unsatisfiable against ReservoirComputing's declared `SciMLBase = "2.51, 3"` (and the `OrdinaryDiffEqCore = "4.10 - 4.13"` cap already used to keep LowOrderRK 2.2.x out). The live extras floor is therefore 2.0.0.

LowOrderRK 1.x is also the series that lacks the two-argument `get_fsalfirstlast` cache method required by current OrdinaryDiffEqCore. That runtime failure is unreachable here only because SciMLBase 2.51+ already excludes 1.2.0.

## Verification

Julia 1.10.11, `Pkg.develop` of this checkout, then `Pkg.add(name="OrdinaryDiffEqLowOrderRK", version=...)`:

| OrdinaryDiffEqLowOrderRK | Result |
|---|---|
| 1.2.0 (old floor) | unsatisfiable against SciMLBase 2.51+ |
| 2.0.0 (new floor) | `RESOLVE_OK` OrdinaryDiffEqLowOrderRK 2.0.0 |

Not verified here: the full test suite, QA, or a live `julia-downgrade-compat` run. LinearSolve 5.0.0 `using` succeeded; Dual/`issquare` was not exercised, so that floor is unchanged.
