### PR TITLE
Raise OrdinaryDiffEq extras floor to 7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -43,7 +43,7 @@ LinearSolve = "4.2, 5"
 LuxCore = "1.3.0"
 MLJLinearModels = "0.9.2, 0.10"
 NNlib = "0.9.30"
-OrdinaryDiffEq = "6, 7"
+OrdinaryDiffEq = "7"
 # Cap below 4.14: LowOrderRK 2.2.x requires OrdinaryDiffEqCore.u_cache.
 OrdinaryDiffEqCore = "4.10 - 4.13"
 OrdinaryDiffEqLowOrderRK = "1.2, 2"


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

Independent of https://github.com/SciML/ReservoirComputing.jl/pull/500 (LowOrderRK floor).

## What changed

Pure `[compat]` lower-bound bump for a test extra:

- `OrdinaryDiffEq = "6, 7"` → `"7"`

No library code, tests, or package version were changed.

## Why

ReservoirComputing already requires `OrdinaryDiffEqCore = "4.10 - 4.13"` (ODE 7 generation). OrdinaryDiffEq 6.0.0 and 6.87.0 cannot resolve against that Core window plus `SciMLBase = "2.51, 3"`. The declared `"6, 7"` extras floor therefore allows a dead 6.x range.

## Verification

Julia 1.10.11, `Pkg.develop` of this checkout, then `Pkg.add(name="OrdinaryDiffEq", version=...)`:

| OrdinaryDiffEq | Result |
|---|---|
| 6.0.0 (old 6.x floor) | unsatisfiable vs SciMLBase 2.51+ / OrdinaryDiffEqCore 4.10–4.13 |
| 6.87.0 | unsatisfiable (same Core 4.x window) |
| 7.0.0 (new floor) | `RESOLVE_OK` |

Not verified here: the full test suite, QA, or a live `julia-downgrade-compat` run.
