### PR TITLE
fix: resolve leftover dev-comment

### DIFF
--- a/src/ReservoirComputing.jl
+++ b/src/ReservoirComputing.jl
@@ -18,8 +18,6 @@ using WeightInitializers: orthogonal, rand32, randn32, sparse_init, zeros32
 
 include("initializer_utils.jl")
 
-#@compat(public, (initialparameters)) #do I need to add intialstates/parameters in compat?
-
 #reservoir computers
 include("generics.jl")
 include("layers/sciml_reservoir.jl")

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -3,6 +3,8 @@ const InputType = Tuple{<:AbstractArray, Tuple{<:AbstractArray}}
 const IntegerType = Union{Integer, StaticInt}
 const RCFields = (:cells, :state_modifiers, :readout)
 
+__quote_keys(t) = Expr(:tuple, (QuoteNode(s) for s in t)...)
+
 """
     AbstractReservoirComputer{Fields} <: AbstractLuxContainerLayer{Fields}
 

--- a/src/inits/inits_components.jl
+++ b/src/inits/inits_components.jl
@@ -188,7 +188,6 @@ function bernoulli_sample!(
     return
 end
 
-#TODO: @MartinuzziFrancesco maybe change name here #wait, for sure change name here
 function irrational_sample!(
         rng::AbstractRNG, vecormat::AbstractVecOrMat;
         irrational::Irrational = pi, start::Int = 1

--- a/src/layers/svmreadout.jl
+++ b/src/layers/svmreadout.jl
@@ -56,8 +56,6 @@ function wrap_functions_in_chain_call(ro::SVMReadout)
     return __svmreadout_include_collect(ro) ? (Collect(), ro) : ro
 end
 
-__quote_keys(t) = Expr(:tuple, (QuoteNode(s) for s in t)...)
-
 function __setmodels_rt(p::NamedTuple{K}, M) where {K}
     keys = K
     Kq = __quote_keys(keys)

--- a/src/models/ngrc.jl
+++ b/src/models/ngrc.jl
@@ -83,7 +83,7 @@ function NGRC(
         inc = ReservoirComputing.known(include_input)
         n_blocks = (inc === true ? 1 : 0) + length(feats_tuple)
         ro_dims = n_taps * n_blocks
-        @warn """
+        !isempty(feats_tuple) && @warn """
             NGRC: inferring readout input dimension assuming each feature f in `features`
             returns a vector of the same length as the delayed input.
 

--- a/src/train.jl
+++ b/src/train.jl
@@ -250,8 +250,6 @@ function train(
     return return_states ? ((ps2, st_after), states_wo) : (ps2, st_after)
 end
 
-#__quote_keys(t) = Expr(:tuple, (QuoteNode(s) for s in t)...)
-
 @generated function __setweight_rt(p::NamedTuple{K}, W) where {K}
     keys = K
     Kq = __quote_keys(keys)


### PR DESCRIPTION
Removes stale dev comments (unresolved rename TODO in irrational_sample!, dead commented-out @compat public line), moves __quote_keys into generics.jl so train.jl no longer relies on svmreadout.jl's include order to define it, and silences NGRC's ro_dims inference warning when no feature functions are passed (the inferred dimension is exact in that case).
