### PR TITLE
fix: preserve autoregressive predict backend

### DIFF
--- a/src/predict.jl
+++ b/src/predict.jl
@@ -29,6 +29,11 @@ sequence.
 - `output`: Generated outputs of shape `(out_dims, steps)`.
 - `st`: Final model state after `steps` steps.
 
+### Throws
+
+- `ArgumentError`: If `steps < 1`.
+- `DimensionMismatch`: If a model output cannot be fed back as the next input.
+
 
 ## 2) Teacher-forced / point-by-point
 
@@ -51,12 +56,35 @@ function predict(
         rc::AbstractLuxLayer,
         steps::Integer, ps, st; initialdata::AbstractVector
     )
-    output = zeros(eltype(initialdata), length(initialdata), steps)
-    for step in 1:steps
-        initialdata, st = apply(rc, initialdata, ps, st)
-        output[:, step] = initialdata
+    return __autoregressive_predict(rc, steps, ps, st, initialdata)
+end
+
+function __require_closed_loop_dimension(output, input_length::Integer, step::Integer)
+    output_length = length(output)
+    output_length == input_length || throw(
+        DimensionMismatch(
+            "autoregressive predict requires each output to have length $input_length " *
+                "so it can be used as the next input; step $step produced length " *
+                "$output_length"
+        )
+    )
+    return nothing
+end
+
+function __autoregressive_predict(rc, steps::Integer, ps, st, initialdata::AbstractVector)
+    steps ≥ 1 || throw(ArgumentError("steps must be ≥ 1, got $steps"))
+    input_length = length(initialdata)
+    current_output, st = apply(rc, initialdata, ps, st)
+    __require_closed_loop_dimension(current_output, input_length, 1)
+
+    outputs = similar(current_output, length(current_output), steps)
+    outputs[:, 1] .= current_output
+    for step in 2:steps
+        current_output, st = apply(rc, current_output, ps, st)
+        __require_closed_loop_dimension(current_output, input_length, step)
+        outputs[:, step] .= current_output
     end
-    return output, st
+    return outputs, st
 end
 
 function predict(rc::AbstractLuxLayer, data::AbstractMatrix, ps, st)
@@ -129,12 +157,7 @@ function __predict(
         ::Any, rc::AbstractReservoirComputer, steps::Integer, ps, st;
         initialdata::AbstractVector
     )
-    output = zeros(eltype(initialdata), length(initialdata), steps)
-    for step in 1:steps
-        initialdata, st = apply(rc, initialdata, ps, st)
-        output[:, step] = initialdata
-    end
-    return output, st
+    return __autoregressive_predict(rc, steps, ps, st, initialdata)
 end
 
 function __predict(::Any, rc::AbstractReservoirComputer, data::AbstractMatrix, ps, st)

--- a/test/CUDA/cuda_tests.jl
+++ b/test/CUDA/cuda_tests.jl
@@ -132,6 +132,29 @@ begin
                 @test pred_gpu isa CUDA.CuArray
                 @test Array(pred_gpu) ≈ pred_cpu
                 @test propertynames(st_pred) == propertynames(st)
+
+                autoregressive_rc = ReservoirChain(
+                    identity,
+                    LinearReadout(
+                        2 => 2,
+                        identity;
+                        include_collect = false,
+                        init_weight = dense_init(Float32; value = 0.5),
+                    ),
+                )
+                ar_ps_cpu, ar_st = setup(rng, autoregressive_rc)
+                ar_ps_gpu = to_device(ar_ps_cpu)
+                initial_cpu = Float32[0.2, 0.4]
+                initial_gpu = CUDA.cu(initial_cpu)
+                ar_gpu, ar_st_gpu = predict(
+                    autoregressive_rc, 3, ar_ps_gpu, ar_st; initialdata = initial_gpu
+                )
+                ar_cpu, _ = predict(
+                    autoregressive_rc, 3, ar_ps_cpu, ar_st; initialdata = initial_cpu
+                )
+                @test ar_gpu isa CUDA.CuArray
+                @test Array(ar_gpu) ≈ ar_cpu
+                @test propertynames(ar_st_gpu) == propertynames(ar_st)
             end
         end
     end

--- a/test/Interface/array_workflow_tests.jl
+++ b/test/Interface/array_workflow_tests.jl
@@ -142,6 +142,26 @@ begin
         end
     end
 
+    @testset "autoregressive predict follows output storage and dimensions" begin
+        rng = MersenneTwister(203)
+        readout = LinearReadout(
+            2 => 2;
+            include_collect = false,
+            init_weight = (rng, out, in) -> Matrix{Float64}(I, out, in),
+        )
+        ps, st = setup(rng, readout)
+        output, _ = predict(readout, 3, ps, st; initialdata = Float32[1, 2])
+        @test output == [1.0 1.0 1.0; 2.0 2.0 2.0]
+        @test eltype(output) === Float64
+
+        mismatched = LinearReadout(2 => 3; include_collect = false)
+        mismatched_ps, mismatched_st = setup(rng, mismatched)
+        @test_throws DimensionMismatch predict(
+            mismatched, 2, mismatched_ps, mismatched_st; initialdata = Float32[1, 2]
+        )
+        @test_throws ArgumentError predict(readout, 0, ps, st; initialdata = Float32[1, 2])
+    end
+
     @testset "ESN workflow trains and predicts across eltypes" begin
         for T in (Float32, Float64), use_bias in (False(), True())
             rng = MersenneTwister(303)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  