### PR TITLE
Restore the documented LuxCore and WeightInitializers reexports

### DIFF
--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -28,6 +28,7 @@ pages = [
         "States" => "api/states.md",
         "Initializers" => "api/inits.md",
         "Developer Interfaces" => "api/developer.md",
+        "Reexported API" => "api/reexports.md",
     ],
     "References" => "references.md",
 ]

--- a/docs/src/api/reexports.md
+++ b/docs/src/api/reexports.md
@@ -1,0 +1,64 @@
+# Reexported API
+
+`using ReservoirComputing` also brings a small, fixed set of names from
+[LuxCore](https://lux.csail.mit.edu/stable/api/Building_Blocks/LuxCore) and
+[WeightInitializers](https://lux.csail.mit.edu/stable/api/Building_Blocks/WeightInitializers)
+into scope, so the tutorials on this site run on `using ReservoirComputing` alone.
+ReservoirComputing does not document these names — it only reexports them. Their
+documentation lives with the packages that own them, linked below.
+
+## Model lifecycle (owned by LuxCore)
+
+Every ReservoirComputing model is an `AbstractLuxLayer`, so it is built with the
+standard LuxCore lifecycle rather than a ReservoirComputing-specific one:
+
+  - `setup(rng, model)` — allocate a model's parameters and states. This is the
+    second line of essentially every tutorial: `ps, st = setup(rng, esn)`, feeding
+    [`train`](train.md) and [`predict`](predict.md).
+  - `apply(model, x, ps, st)` — run a model on an input, returning the output and
+    the updated state.
+
+Owned and documented by
+[LuxCore](https://lux.csail.mit.edu/stable/api/Building_Blocks/LuxCore).
+
+## Custom layer interface (owned by LuxCore)
+
+These are the two methods a custom reservoir cell implements; see
+[Building a model to add to ReservoirComputing.jl](../examples/model_es2n.md) and
+[Developer Interfaces](developer.md):
+
+  - `initialparameters(rng, layer)` — the layer's trainable parameters.
+  - `initialstates(rng, layer)` — the layer's non-trainable state.
+
+Owned and documented by
+[LuxCore](https://lux.csail.mit.edu/stable/api/Building_Blocks/LuxCore).
+
+Anything else from LuxCore — `AbstractLuxLayer`, `statelength`, `outputsize`,
+`replicate` and the container-layer supertypes — must be imported from LuxCore
+directly. Those are extension hook points rather than names a model user calls.
+
+## Default weight initializers (owned by WeightInitializers)
+
+The cell constructors take `init_input`, `init_reservoir`, `init_bias`, `init_state`
+and `init_orthogonal` keyword arguments. Most defaults are ReservoirComputing's own
+initializers (see [Initializers](inits.md)), but five come from WeightInitializers and
+are reexported so that overriding one keyword does not force you to import the
+package just to name the defaults for the others:
+
+  - `zeros32` — default `init_bias` on most cells, default `init_state` on
+    `LIFESNCell`, and default `init_delay` on `DelayLayer`.
+  - `randn32` — default `init_state` on `ESNCell`, `ES2NCell`, `ResESNCell` and
+    `MemoryESNCell`.
+  - `rand32` — default `init_weight`/`init_bias` on `LinearReadout` and default
+    `init_bias` on `MemoryESNCell`.
+  - `orthogonal` — default `init_orthogonal` on `ES2NCell` and `ResESNCell`.
+  - `sparse_init` — the sparse sampler behind `rand_sparse` and `dale_sparse`.
+
+Owned and documented by
+[WeightInitializers](https://lux.csail.mit.edu/stable/api/Building_Blocks/WeightInitializers).
+
+The rest of the WeightInitializers surface — `glorot_normal`, `glorot_uniform`,
+`kaiming_normal`, `kaiming_uniform`, `identity_init`, `truncated_normal` and the
+16/64-bit and complex `ones*`/`rand*`/`randn*`/`zeros*` variants — is **not**
+reexported and must be imported from WeightInitializers directly. They are all valid
+`init_*` arguments; ReservoirComputing simply does not name any of them as a default.

--- a/src/ReservoirComputing.jl
+++ b/src/ReservoirComputing.jl
@@ -71,6 +71,16 @@ include("conceptors.jl")
 #extensions
 include("extensions/reca.jl")
 
+# Reexported upstream API, approved via `reexports_allow` in test/qa/qa.jl. `setup` is
+# used in every tutorial to build a model's parameters and states, `initialparameters` /
+# `initialstates` are what custom cells implement, and `apply` is the other half of that
+# LuxCore layer interface. The WeightInitializers functions are the documented defaults
+# of the `init_bias` / `init_state` / `init_orthogonal` / `init_input` keywords on the
+# cells, so `using ReservoirComputing` alone is enough to name or override them.
+# Everything stays owned and documented upstream.
+export setup, apply, initialparameters, initialstates
+export orthogonal, rand32, randn32, sparse_init, zeros32
+
 export ReservoirComputer
 export AbstractSciMLProblemReservoir, SciMLProblemReservoir, ContinuousESN, LSM
 export AbstractSampler, TerminalStateSampling

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,4 +1,4 @@
-using SciMLTesting, ReservoirComputing
+using SciMLTesting, ReservoirComputing, Test
 using JET
 
 # ExplicitImports only checks an extension module once it exists, and an extension only
@@ -32,8 +32,18 @@ rc_internal_hooks = (
     :addreadout!,
 )
 
+# The LuxCore and WeightInitializers API that ReservoirComputing deliberately reexports so
+# that `using ReservoirComputing` on its own is enough to follow the tutorials. Owned and
+# documented upstream; kept in sync with the reexport `export` block in
+# src/ReservoirComputing.jl.
+const REEXPORTS = (
+    :apply, :initialparameters, :initialstates, :setup,
+    :orthogonal, :rand32, :randn32, :sparse_init, :zeros32,
+)
+
 run_qa(
     ReservoirComputing;
+    reexports_allow = REEXPORTS,
     ei_kwargs = (;
         all_explicit_imports_are_public = (;
             ignore = (
@@ -56,3 +66,14 @@ run_qa(
         ),
     )
 )
+
+@testset "Reexport surface" begin
+    # Every approved reexport must actually be reachable from `using ReservoirComputing`,
+    # so the allow-list cannot drift into approving names the package no longer provides.
+    # `isdefined(@__MODULE__, ...)` tests the property directly: this file's `using
+    # ReservoirComputing` is what has to bring the name into scope.
+    @testset "$name" for name in REEXPORTS
+        @test name in names(ReservoirComputing)
+        @test isdefined(@__MODULE__, name)
+    end
+end


### PR DESCRIPTION
## What was stripped

`cd58707` — "Remove undocumented LuxCore and WeightInitializers reexports (#485)" — deleted

```julia
@reexport using WeightInitializers
@reexport using LuxCore: setup, apply, initialparameters, initialstates
```

from `src/ReservoirComputing.jl`. Everything those two lines put into scope on `using ReservoirComputing` went away with them.

## Why "undocumented" is not right

The stripping commit is its own counter-evidence. To keep CI green it had to add:

* `using LuxCore: setup` to **twelve** documentation pages — `tutorials/getting_started.md`, `lorenz_basic.md`, `deep_esn.md`, `scratch.md`, `train.md`, `reca.md`, `ngrc.md`, `saveload.md`, `continuous_esn.md`, `sciml_reservoir.md`, `examples/model_es2n.md`, and `docs/Project.toml` gained `LuxCore` and `WeightInitializers` as dependencies;
* `using LuxCore: ...` / `import LuxCore: ...` to roughly twenty test files, plus `test/shared/generic_testsetup.jl` which previously did `using ReservoirComputing: setup`;
* `using WeightInitializers: orthogonal, randn32, zeros32` to `examples/model_es2n.md` and `tutorials/getting_started.md`, and `using WeightInitializers: zeros32` to `test/basic_tests.jl` and `test/Models/ngrc_tests.jl`.

`ps, st = setup(rng, model)` is the second line of essentially every tutorial — it is how a model gets its parameters and states before `train`/`predict`. So `using ReservoirComputing` alone stopped being enough to follow the documentation.

## What is restored, and the evidence for each name

Per "we should be reexporting what is normal documented use, but not whole dependencies", this is an explicit `export` list, not a restored blanket `@reexport` — mirroring SciML/Sundials.jl#553.

**LuxCore** — `setup`, `apply`, `initialparameters`, `initialstates`

* `setup` appears in all 13 tutorial/example pages (`grep -c "setup(" docs/src` → 37 hits).
* `initialparameters` / `initialstates` are what a custom cell implements; used in `docs/src/examples/model_es2n.md`, `docs/src/api/developer.md`, and ~15 test files.
* `apply` is the other half of that LuxCore layer interface and was part of the removed line; kept rather than guessed away.

**WeightInitializers** — `orthogonal`, `rand32`, `randn32`, `sparse_init`, `zeros32`

These are exactly the five that `src/ReservoirComputing.jl` already imports, and exactly the ones named as documented defaults in the cell docstrings:

* `ESNCell`/`ES2NCell`/`ResESNCell`/`MemoryESNCell`: `init_bias = zeros32`, `init_state = randn32`, `init_orthogonal = orthogonal`, `init_bias = rand32`
* `LIFESNCell`: `init_bias = zeros32`, `init_state = zeros32`
* `DelayLayer`: `init_delay = zeros32`, docstring "e.g. `zeros32`, `randn32`"
* `LinearReadout`: `init_weight = rand32`, `init_bias = rand32`
* `sparse_init` backs `rand_sparse` and `dale_sparse`

A user overriding one `init_*` keyword needs to be able to name the defaults for the others.

## What is deliberately not restored

The rest of WeightInitializers' surface — `glorot_normal`, `glorot_uniform`, `kaiming_normal`, `kaiming_uniform`, `identity_init`, `truncated_normal`, and the 16/64-bit and complex `ones*`/`rand*`/`randn*`/`zeros*` variants — is not referenced by any ReservoirComputing doc page, docstring or test, so it stays behind `using WeightInitializers`. Same for LuxCore's `statelength`/`outputsize`/`replicate`, which are extension hooks rather than user-facing calls.

## Documentation

New page `docs/src/api/reexports.md`, wired into the "API Documentation" section of `docs/pages.jl`. It groups the nine names by role — model lifecycle (`setup`, `apply`), custom layer interface (`initialparameters`, `initialstates`), default weight initializers (`zeros32`, `randn32`, `rand32`, `orthogonal`, `sparse_init`) — names the owning package for each group with a link to its documentation, says which cell keyword each initializer is the default for, and closes each section with the explicit boundary: anything else from LuxCore or WeightInitializers must be imported from those packages directly.

## Drift protection

`test/qa/qa.jl` declares the same list via `reexports_allow = REEXPORTS` and adds a testset asserting each approved name is both in `names(ReservoirComputing)` and actually in scope from this file's `using ReservoirComputing`, so the allow-list cannot drift from the exports.

## Semver

Restoring names that used to be exported is **not** breaking — a patch/minor bump. No version bump is included here; a separate release pass handles versions.

## Verified

Run locally on this branch (macOS aarch64, Julia 1.11.8):

* `using ReservoirComputing` loads; all nine names are in `names(ReservoirComputing)` and in scope. Exported count 150.
* `julia --project=test/qa test/qa/qa.jl` — **Quality Assurance: 21/21 pass**, **Reexport surface: 18/18 pass**.
* Runic v1 `--check` clean on the changed Julia files (`src/ReservoirComputing.jl`, `test/qa/qa.jl`, `docs/pages.jl`); `typos` clean on all changed files.
* External documentation links in the new page return HTTP 200.

Not run: the full `Pkg.test()` suite, and the Documenter build (this machine is heavily loaded by other jobs). The code changes are export-only plus QA; `linkcheck = false` in `docs/make.jl`, and the new page's external links were checked by hand.

## Note on the docs

The explicit `using LuxCore: setup` lines the stripping commit added to the docs are left in place — they are harmless now that the names are reexported again, and removing them would be churn across 12 files. They can be dropped in a follow-up if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ

