### PR TITLE
docs: add missing models to readme and index

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,26 +36,31 @@ reservoir computing models. More specifically the software offers:
 - Base layers for reservoir computing model construction
   such as `ReservoirComputer` and `ReservoirChain`.
 - Additional, lower level building blocks for custom reservoir computers,
-  such as `Collect`, `ESNCell`, `SciMLProblemReservoir`, `DelayLayer`,
-  `NonlinearFeaturesLayer`, `MemoryESNCell`, `LinearReadout`, `SVMReadout`,
-  and more
+  such as `Collect`, `ESNCell`, `DelayLayer`, `NonlinearFeaturesLayer`,
+  `MemoryESNCell`, `LinearReadout`, `SVMReadout`, and more
 - Fully built models:
-    + [Echo state networks](https://doi.org/10.1126/science.1091277) `ESN`
-    + [Deep echo state networks](https://doi.org/10.1016/j.neunet.2018.08.002) `DeepESN`
-    + [Echo state networks with delays](https://doi.org/10.1063/5.0258250) `DelayESN`/`InputDelayESN`/`StateDelayESN`
-    + [Edge of stability echo state networks](https://doi.org/10.1109/tnnls.2024.3400045) `ES2N`
-    + [Euler state networks](https://doi.org/10.1016/j.neucom.2024.127411) `EuSN`
-    + [Hybrid echo state networks](https://doi.org/10.1063/1.5028373) `HybridESN`
-    + [Neuromorphic reservoir computing](https://doi.org/10.1063/5.0282708) `EIESN`/`AdditiveEIESN`
-    + [Support vector echo-state machine](https://doi.org/10.1109/TNN.2006.885113) `SVESM`
-    + [Local information flow echo state network](https://doi.org/10.1007/s11071-025-10942-6) `LIFESN`
-    + [Residual echo state networks](https://doi.org/10.1016/j.neucom.2024.127966) `ResESN`
-    + [Next generation reservoir computing](https://doi.org/10.1038/s41467-021-25801-2) `NGRC`
-    + [Reservoir memory networks](https://doi.org/10.14428/ESANN/2024.ES2024-117) `RMNCell`/`RMNESN` / `RMNResESN`
-    + [Continuous-time echo state networks](https://doi.org/10.1007/978-3-642-35289-8_36) `ContinuousESN`
+    + ESN variations:
+        * [Echo state networks](https://doi.org/10.1126/science.1091277) `ESN`
+        * [Echo state networks with delays](https://doi.org/10.1063/5.0258250) `DelayESN`/`InputDelayESN`/`StateDelayESN`
+        * [Edge of stability echo state networks](https://doi.org/10.1109/tnnls.2024.3400045) `ES2N`
+        * [Euler state networks](https://doi.org/10.1016/j.neucom.2024.127411) `EuSN`
+        * [Hybrid echo state networks](https://doi.org/10.1063/1.5028373) `HybridESN`
+        * [Neuromorphic reservoir computing](https://doi.org/10.1063/5.0282708) `EIESN`/`AdditiveEIESN`
+        * [Support vector echo-state machine](https://doi.org/10.1109/TNN.2006.885113) `SVESM`
+        * [Residual echo state networks](https://doi.org/10.1016/j.neucom.2024.127966) `ResESN`
+        * [Reservoir memory networks](https://doi.org/10.14428/ESANN/2024.ES2024-117) `RMNCell`/`RMNESN`/`RMNResESN`
+        * [Deep echo state networks](https://doi.org/10.1016/j.neunet.2018.08.002) `DeepESN`
+        * [Local information flow echo state network](https://doi.org/10.1007/s11071-025-10942-6) `LIFESN`
     + [Liquid state machines](https://doi.org/10.1162/089976602760407955) `LSM`
     + [Conceptors](https://arxiv.org/abs/1403.3369) `Conceptor`
+    + [Next generation reservoir computing](https://doi.org/10.1038/s41467-021-25801-2) `NGRC`
     + [Reservoir computing with cellular automata](https://arxiv.org/abs/1410.0162) `RECA`
+- Wrappers:
+    + [Deep reservoirs](https://doi.org/10.1016/j.neunet.2018.08.002) `DeepReservoir`
+    + [Local information flow](https://doi.org/10.1007/s11071-025-10942-6) `LocalInformationFlow`
+- Continuous time reservoirs:
+    + `SciMLProblemReservoir`
+    + [Continuous-time echo state networks](https://doi.org/10.1007/978-3-642-35289-8_36) `ContinuousESN`
 - 20+ reservoir initializers and 5+ input layer initializers
 - 5+ reservoir states modification algorithms
 - Sparse matrix computation through

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@
 # ReservoirComputing.jl
 
 ReservoirComputing.jl provides an efficient, modular and easy to use
-implementation of Reservoir Computing models such as Echo State Networks (ESNs).
+implementation of Reservoir Computing models such as Echo State Networks (ESNs),
+liquid state machines, and conceptors.
 For information on using this package please refer to the
 [stable documentation](https://docs.sciml.ai/ReservoirComputing/stable/).
 Use the
@@ -35,8 +36,9 @@ reservoir computing models. More specifically the software offers:
 - Base layers for reservoir computing model construction
   such as `ReservoirComputer` and `ReservoirChain`.
 - Additional, lower level building blocks for custom reservoir computers,
-  such as `Collect`, `ESNCell`, `DelayLayer`, `NonlinearFeaturesLayer`,
-  `MemoryESNCell`, `LinearReadout`, `SVMReadout`, and more
+  such as `Collect`, `ESNCell`, `SciMLProblemReservoir`, `DelayLayer`,
+  `NonlinearFeaturesLayer`, `MemoryESNCell`, `LinearReadout`, `SVMReadout`,
+  and more
 - Fully built models:
     + [Echo state networks](https://doi.org/10.1126/science.1091277) `ESN`
     + [Deep echo state networks](https://doi.org/10.1016/j.neunet.2018.08.002) `DeepESN`
@@ -50,6 +52,10 @@ reservoir computing models. More specifically the software offers:
     + [Residual echo state networks](https://doi.org/10.1016/j.neucom.2024.127966) `ResESN`
     + [Next generation reservoir computing](https://doi.org/10.1038/s41467-021-25801-2) `NGRC`
     + [Reservoir memory networks](https://doi.org/10.14428/ESANN/2024.ES2024-117) `RMNCell`/`RMNESN` / `RMNResESN`
+    + [Continuous-time echo state networks](https://doi.org/10.1007/978-3-642-35289-8_36) `ContinuousESN`
+    + [Liquid state machines](https://doi.org/10.1162/089976602760407955) `LSM`
+    + [Conceptors](https://arxiv.org/abs/1403.3369) `Conceptor`
+    + [Reservoir computing with cellular automata](https://arxiv.org/abs/1410.0162) `RECA`
 - 20+ reservoir initializers and 5+ input layer initializers
 - 5+ reservoir states modification algorithms
 - Sparse matrix computation through

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,7 +1,8 @@
 # ReservoirComputing.jl
 
 ReservoirComputing.jl is a versatile and user-friendly Julia package designed
-for the implementation of Reservoir Computing models, such as Echo State Networks (ESNs).
+for the implementation of Reservoir Computing models, such as Echo State Networks (ESNs),
+liquid state machines, and conceptors.
 Reservoir Computing expands the input data into a higher-dimensional
 space, leveraging regression techniques for effective model training.
 This approach can be thought as a kernel method with an explicit kernel trick.
@@ -75,7 +76,8 @@ or `dev` the package.
   such as [`ReservoirChain`](@ref).
 - Additional, lower level building blocks for custom reservoir computers,
   such as [`Collect`](@ref), [`ESNCell`](@ref), [`ES2NCell`](@ref),
-  [`DelayLayer`](@ref), [`NonlinearFeaturesLayer`](@ref), [`LinearReadout`](@ref),
+  [`SciMLProblemReservoir`](@ref), [`DelayLayer`](@ref),
+  [`NonlinearFeaturesLayer`](@ref), [`LinearReadout`](@ref),
   [`SVMReadout`](@ref), and more.
 - Fully built models:
     + [Echo state networks](https://doi.org/10.1126/science.1091277)  [`ESN`](@ref)
@@ -90,6 +92,10 @@ or `dev` the package.
     + [Residual echo state networks](https://doi.org/10.1016/j.neucom.2024.127966)  [`ResESN`](@ref)
     + [Next generation reservoir computing](https://doi.org/10.1038/s41467-021-25801-2)  [`NGRC`](@ref)
     + [Reservoir memory networks](https://doi.org/10.14428/ESANN/2024.ES2024-117) [`RMNCell`](@ref)/[`RMNESN`](@ref)/[`RMNResESN`](@ref)
+    + [Continuous-time echo state networks](https://doi.org/10.1007/978-3-642-35289-8_36)  [`ContinuousESN`](@ref)
+    + [Liquid state machines](https://doi.org/10.1162/089976602760407955)  [`LSM`](@ref)
+    + [Conceptors](https://arxiv.org/abs/1403.3369)  [`Conceptor`](@ref)
+    + [Reservoir computing with cellular automata](https://arxiv.org/abs/1410.0162)  [`RECA`](@ref)
 - 20+ reservoir initializers and 5+ input layer initializers
 - 5+ reservoir states modification algorithms
 - Sparse matrix computation through

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -76,26 +76,31 @@ or `dev` the package.
   such as [`ReservoirChain`](@ref).
 - Additional, lower level building blocks for custom reservoir computers,
   such as [`Collect`](@ref), [`ESNCell`](@ref), [`ES2NCell`](@ref),
-  [`SciMLProblemReservoir`](@ref), [`DelayLayer`](@ref),
-  [`NonlinearFeaturesLayer`](@ref), [`LinearReadout`](@ref),
+  [`DelayLayer`](@ref), [`NonlinearFeaturesLayer`](@ref), [`LinearReadout`](@ref),
   [`SVMReadout`](@ref), and more.
 - Fully built models:
-    + [Echo state networks](https://doi.org/10.1126/science.1091277)  [`ESN`](@ref)
-    + [Deep echo state networks](https://doi.org/10.1016/j.neunet.2018.08.002)  [`DeepESN`](@ref)
-    + [Echo state networks with delays](https://doi.org/10.1063/5.0258250)  [`DelayESN`](@ref)/[`InputDelayESN`](@ref)/[`StateDelayESN`](@ref)
-    + [Edge of stability echo state networks](https://doi.org/10.1109/tnnls.2024.3400045)  [`ES2N`](@ref)
-    + [Euler state networks](https://doi.org/10.1016/j.neucom.2024.127411)  [`EuSN`](@ref)
-    + [Hybrid echo state networks](https://doi.org/10.1063/1.5028373)  [`HybridESN`](@ref)
-    + [Neuromorphic reservoir computing](https://doi.org/10.1063/5.0282708)  [`EIESN`](@ref)/[`AdditiveEIESN`](@ref)
-    + [Support vector echo-state machine](https://doi.org/10.1109/TNN.2006.885113)  [`SVESM`](@ref)
-    + [Local information flow echo state network](https://doi.org/10.1007/s11071-025-10942-6)  [`LIFESN`](@ref)
-    + [Residual echo state networks](https://doi.org/10.1016/j.neucom.2024.127966)  [`ResESN`](@ref)
-    + [Next generation reservoir computing](https://doi.org/10.1038/s41467-021-25801-2)  [`NGRC`](@ref)
-    + [Reservoir memory networks](https://doi.org/10.14428/ESANN/2024.ES2024-117) [`RMNCell`](@ref)/[`RMNESN`](@ref)/[`RMNResESN`](@ref)
-    + [Continuous-time echo state networks](https://doi.org/10.1007/978-3-642-35289-8_36)  [`ContinuousESN`](@ref)
+    + ESN variations:
+        * [Echo state networks](https://doi.org/10.1126/science.1091277)  [`ESN`](@ref)
+        * [Echo state networks with delays](https://doi.org/10.1063/5.0258250)  [`DelayESN`](@ref)/[`InputDelayESN`](@ref)/[`StateDelayESN`](@ref)
+        * [Edge of stability echo state networks](https://doi.org/10.1109/tnnls.2024.3400045)  [`ES2N`](@ref)
+        * [Euler state networks](https://doi.org/10.1016/j.neucom.2024.127411)  [`EuSN`](@ref)
+        * [Hybrid echo state networks](https://doi.org/10.1063/1.5028373)  [`HybridESN`](@ref)
+        * [Neuromorphic reservoir computing](https://doi.org/10.1063/5.0282708)  [`EIESN`](@ref)/[`AdditiveEIESN`](@ref)
+        * [Support vector echo-state machine](https://doi.org/10.1109/TNN.2006.885113)  [`SVESM`](@ref)
+        * [Residual echo state networks](https://doi.org/10.1016/j.neucom.2024.127966)  [`ResESN`](@ref)
+        * [Reservoir memory networks](https://doi.org/10.14428/ESANN/2024.ES2024-117) [`RMNCell`](@ref)/[`RMNESN`](@ref)/[`RMNResESN`](@ref)
+        * [Deep echo state networks](https://doi.org/10.1016/j.neunet.2018.08.002)  [`DeepESN`](@ref)
+        * [Local information flow echo state network](https://doi.org/10.1007/s11071-025-10942-6)  [`LIFESN`](@ref)
     + [Liquid state machines](https://doi.org/10.1162/089976602760407955)  [`LSM`](@ref)
     + [Conceptors](https://arxiv.org/abs/1403.3369)  [`Conceptor`](@ref)
+    + [Next generation reservoir computing](https://doi.org/10.1038/s41467-021-25801-2)  [`NGRC`](@ref)
     + [Reservoir computing with cellular automata](https://arxiv.org/abs/1410.0162)  [`RECA`](@ref)
+- Wrappers:
+    + [Deep reservoirs](https://doi.org/10.1016/j.neunet.2018.08.002)  [`DeepReservoir`](@ref)
+    + [Local information flow](https://doi.org/10.1007/s11071-025-10942-6)  [`LocalInformationFlow`](@ref)
+- Continuous time reservoirs:
+    + [`SciMLProblemReservoir`](@ref)
+    + [Continuous-time echo state networks](https://doi.org/10.1007/978-3-642-35289-8_36)  [`ContinuousESN`](@ref)
 - 20+ reservoir initializers and 5+ input layer initializers
 - 5+ reservoir states modification algorithms
 - Sparse matrix computation through


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/ColPrac)
- [x] Any new documentation only uses public API

## Additional context

README and `index.md` still listed ESN variants only. Adds `ContinuousESN`, `LSM`, `Conceptor`, `RECA`, and `SciMLProblemReservoir` in the existing paper-link format. Docs only.

Refs #523