### PR TITLE
Format for Runic v1.10

### DIFF
--- a/src/conceptors.jl
+++ b/src/conceptors.jl
@@ -1057,9 +1057,9 @@ function optimal_aperture(
     isempty(apertures) && throw(ArgumentError("apertures must not be empty"))
     attenuations = [
         attenuation(
-                concept, ps, st;
-                conceptor = conceptor_matrix(correlation, aperture), kwargs...
-            ) for aperture in apertures
+            concept, ps, st;
+            conceptor = conceptor_matrix(correlation, aperture), kwargs...
+        ) for aperture in apertures
     ]
     return apertures[argmin(attenuations)], attenuations
 end

--- a/src/layers/lux_layers.jl
+++ b/src/layers/lux_layers.jl
@@ -173,13 +173,13 @@ end
     st_symbols = [gensym() for _ in 1:N]
     calls = [
         :(
-                (
-                    $(x_symbols[i + 1]),
-                    $(st_symbols[i]),
-                ) = @inline apply(
-                    layers.$(fields[i]), $(x_symbols[i]), ps.$(fields[i]), st.$(fields[i])
-                )
+            (
+                $(x_symbols[i + 1]),
+                $(st_symbols[i]),
+            ) = @inline apply(
+                layers.$(fields[i]), $(x_symbols[i]), ps.$(fields[i]), st.$(fields[i])
             )
+        )
             for i in 1:N
     ]
     push!(calls, :(st = NamedTuple{$fields}((($(Tuple(st_symbols)...),)))))

--- a/test/Models/conceptors_tests.jl
+++ b/test/Models/conceptors_tests.jl
@@ -178,14 +178,14 @@ begin
             output = vec(outputs)
             best = minimum(
                 sqrt(
-                        mean(
-                            abs2,
-                            output .- [
-                                sign * sin(2pi * index / period + phase) for
+                    mean(
+                        abs2,
+                        output .- [
+                            sign * sin(2pi * index / period + phase) for
                                 index in eachindex(output)
-                            ],
-                        )
-                    ) / std(output) for phase in 0:0.02:2pi, sign in (-1.0, 1.0)
+                        ],
+                    )
+                ) / std(output) for phase in 0:0.02:2pi, sign in (-1.0, 1.0)
             )
             @test best < 0.05
             @test count(>(0.5), conceptor_singular_values(get_conceptor(st, :sine))) < 80


### PR DESCRIPTION
## What changed and why

Runic v1.10.0 changed multiline generator-element indentation. This PR applies the formatter output required by that release; it contains no behavioral, dependency, or public-API changes.

**Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Verification

Failing before formatting at `1dba1d57050a`:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 1]
```

Passing after formatting:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 0]
$ git diff HEAD^ --check
[exit 0]
$ typos src/conceptors.jl src/layers/lux_layers.jl test/Models/conceptors_tests.jl
[exit 0]
$ GROUP=QA ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA/qa.jl      |   39     39  5m01.4s
Testing ReservoirComputing tests passed
$ GROUP=All ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Models/conceptors_tests.jl | 91 pass, 91 total
Models/deep_reservoir_tests.jl | 59 pass, 59 total
Models/esn_delay_tests.jl | 88 pass, 88 total
Models/esn_tests.jl | 191 pass, 191 total
Testing ReservoirComputing tests passed
```

## Not verified

- Docs were not built because no docstring, `docs/`, or public API changed.
- GPU, downstream, and allowed-to-fail jobs were not run locally.

## Reviewer note

This is a mechanical Runic-only change; the source and test diff should be reviewed as formatting output.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)
