### PR TITLE
feat(inits): add @topology macro for bang-block initializers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReservoirComputing"
 uuid = "7c2d2b1e-3dd4-11ea-355a-8f6a8116e294"
-version = "0.12.40"
+version = "0.12.41"
 authors = ["Francesco Martinuzzi"]
 
 [deps]

--- a/docs/src/api/inits.md
+++ b/docs/src/api/inits.md
@@ -83,6 +83,8 @@ where full details and examples are provided.
 
 ## Building functions
 
+- [`@topology`](inits/topology.md): Builds a reservoir initializer from a
+    stack of building-block mutators.
 - [`add_jumps!`](inits/add_jumps!.md): Inserts jump connections at
     fixed intervals into an existing reservoir.
 - [`backward_connection!`](inits/backward_connection!.md): Adds backward

--- a/docs/src/api/inits/topology.md
+++ b/docs/src/api/inits/topology.md
@@ -1,5 +1,37 @@
 # @topology
 
+Reservoir topologies such as [`selfloop_cycle`](@ref) are stacks of bang
+building blocks. [`@topology`](@ref) writes that stack as an initializer.
+
+```@example topology
+using ReservoirComputing
+
+@topology my_cycle begin
+    self_loop!
+    simple_cycle!
+end
+
+my_cycle(5, 5)
+```
+
+The result is a normal initializer, so it can be passed to `init_reservoir`:
+
+```@example topology
+ESN(1, 50, 1; init_reservoir = my_cycle(; cycle_weight = 0.2))
+```
+
+`alias = block!` names that block's weight. Sign kwargs stay on the original
+block (`delay_kwargs`):
+
+```@example topology
+@topology my_forward begin
+    self_loop!
+    forward = delay_line!(shift = 2)
+end
+
+my_forward(5, 5; forward_weight = 0.5)
+```
+
 ```@docs
     @topology
 ```

--- a/docs/src/api/inits/topology.md
+++ b/docs/src/api/inits/topology.md
@@ -1,0 +1,5 @@
+# @topology
+
+```@docs
+    @topology
+```

--- a/src/ReservoirComputing.jl
+++ b/src/ReservoirComputing.jl
@@ -44,6 +44,7 @@ include("predict.jl")
 include("train.jl")
 #initializers
 include("inits/inits_components.jl")
+include("inits/inits_topology.jl")
 include("inits/inits_input.jl")
 include("inits/inits_reservoir.jl")
 include("inits/inits_lsm.jl")
@@ -107,6 +108,7 @@ export band_init, block_diagonal, chaotic_init, cycle_jumps, delay_line, delayli
     selfloop_forwardconnection, simple_cycle, toeplitz_init, true_doublecycle, wigner_init
 export add_jumps!, backward_connection!, delay_line!, permute_matrix!, reverse_simple_cycle!,
     scale_radius!, self_loop!, simple_cycle!
+export @topology
 export polynomial_monomials, chebyshev_monomials, predict, QRSolver, QRFactorization,
     resetcarry!, return_init_as, train, train!
 export AdditiveEIESN, DeepESN, DeepReservoir, DelayESN, EIESN, ES2N, ESN, EuSN, HybridESN, InputDelayESN, LIFESN, ResESN, StateDelayESN, SVESM

--- a/src/inits/inits_topology.jl
+++ b/src/inits/inits_topology.jl
@@ -142,7 +142,7 @@ function __topology_expand(name::Symbol, body)
         end,
     )
     return quote
-        Base.@__doc__ $primary
+        $primary
         function $name(dims::Integer...; kwargs...)
             return $name($Utils.default_rng(), Float32, dims...; kwargs...)
         end

--- a/src/inits/inits_topology.jl
+++ b/src/inits/inits_topology.jl
@@ -1,4 +1,4 @@
-function _topology_spec(func::Symbol)
+function __topology_spec(func::Symbol)
     func === :delay_line! && return (:delay, :shift, 1)
     func === :backward_connection! && return (:fb, :shift, 1)
     func === :simple_cycle! && return (:cycle, nothing, nothing)
@@ -9,18 +9,18 @@ function _topology_spec(func::Symbol)
     return throw(ArgumentError("@topology unknown building block `$func`"))
 end
 
-function _topology_kw(prefix::Symbol, param::Symbol)
+function __topology_kw(prefix::Symbol, param::Symbol)
     param === :permutation_matrix && return param
     startswith(String(param), String(prefix)) && return param
     return Symbol(prefix, :_, param)
 end
 
-function _topology_weight_kw(prefix::Symbol)
+function __topology_weight_kw(prefix::Symbol)
     prefix === :weight && return :weight
     return Symbol(prefix, :_weight)
 end
 
-function _topology_kws(ex)
+function __topology_kws(ex)
     kws = Dict{Symbol, Any}()
     Meta.isexpr(ex, :call) || return kws
     for arg in ex.args[2:end]
@@ -35,7 +35,7 @@ function _topology_kws(ex)
     return kws
 end
 
-function _topology_entry(stmt)
+function __topology_entry(stmt)
     prefix = nothing
     if Meta.isexpr(stmt, :(=), 2) && stmt.args[1] isa Symbol
         prefix, stmt = stmt.args
@@ -44,21 +44,21 @@ function _topology_entry(stmt)
     func isa Symbol && endswith(String(func), "!") || throw(
         ArgumentError("@topology expected a bang call, got $stmt")
     )
-    return prefix, func, _topology_kws(stmt)
+    return prefix, func, __topology_kws(stmt)
 end
 
-function _typed_kw(name, typ, default)
+function __topology_typed_kw(name, typ, default)
     return Expr(:kw, Expr(:(::), name, typ), default)
 end
 
-function _topology_expand(name::Symbol, body)
+function __topology_expand(name::Symbol, body)
     stmts = Meta.isexpr(body, :block) ?
         filter(s -> !(s isa LineNumberNode), body.args) : Any[body]
     isempty(stmts) && throw(
         ArgumentError("@topology requires at least one building block")
     )
 
-    entries = map(_topology_entry, stmts)
+    entries = map(__topology_entry, stmts)
     n_signs = count(e -> e[2] !== :permute_matrix!, entries)
     used = Set{Symbol}()
     function claim(kw)
@@ -71,7 +71,7 @@ function _topology_expand(name::Symbol, body)
     sign_kws = Any[]
     calls = Expr[]
     for (alias, func, kws) in entries
-        spec_prefix, extra, extra_default = _topology_spec(func)
+        spec_prefix, extra, extra_default = __topology_spec(func)
         weight_prefix = alias === nothing ? spec_prefix : alias
         weighted = func !== :permute_matrix!
         allowed = extra === nothing ? (:weight,) : (:weight, extra)
@@ -82,20 +82,20 @@ function _topology_expand(name::Symbol, body)
 
         args = Any[:rng, :reservoir_matrix]
         if weighted
-            wkw = claim(_topology_weight_kw(weight_prefix))
+            wkw = claim(__topology_weight_kw(weight_prefix))
             wdef = get(kws, :weight, nothing)
             wdef = wdef === nothing ? :(T(0.1f0)) :
                 wdef isa Number ? :(T($wdef)) : wdef
-            push!(sig, _typed_kw(wkw, :(Union{Number, AbstractVector}), wdef))
+            push!(sig, __topology_typed_kw(wkw, :(Union{Number, AbstractVector}), wdef))
             push!(args, :(T.($wkw)))
         end
         if extra !== nothing
             ekw = claim(
-                alias === nothing ? _topology_kw(spec_prefix, extra) : extra
+                alias === nothing ? __topology_kw(spec_prefix, extra) : extra
             )
             etype = extra === :permutation_matrix ?
                 :(Union{Nothing, AbstractMatrix}) : :Integer
-            push!(sig, _typed_kw(ekw, etype, get(kws, extra, extra_default)))
+            push!(sig, __topology_typed_kw(ekw, etype, get(kws, extra, extra_default)))
             push!(args, ekw)
         end
         bang = getfield(@__MODULE__, func)
@@ -104,7 +104,7 @@ function _topology_expand(name::Symbol, body)
                 splat = :kwargs
             else
                 splat = claim(Symbol(spec_prefix, :_kwargs))
-                push!(sign_kws, _typed_kw(splat, :NamedTuple, :(NamedTuple())))
+                push!(sign_kws, __topology_typed_kw(splat, :NamedTuple, :(NamedTuple())))
             end
             push!(calls, Expr(:call, bang, Expr(:parameters, :($splat...)), args...))
         else
@@ -113,8 +113,8 @@ function _topology_expand(name::Symbol, body)
     end
     push!(
         sig,
-        _typed_kw(:radius, :(Union{AbstractFloat, Nothing}), :nothing),
-        _typed_kw(:return_sparse, :Bool, :false),
+        __topology_typed_kw(:radius, :(Union{AbstractFloat, Nothing}), :nothing),
+        __topology_typed_kw(:return_sparse, :Bool, :false),
     )
     if n_signs == 1
         push!(sig, :(kwargs...))
@@ -211,5 +211,5 @@ macro topology(name, body)
     name isa Symbol || throw(
         ArgumentError("@topology first argument must be an identifier, got $name")
     )
-    return esc(_topology_expand(name, body))
+    return esc(__topology_expand(name, body))
 end

--- a/src/inits/inits_topology.jl
+++ b/src/inits/inits_topology.jl
@@ -1,0 +1,215 @@
+function _topology_spec(func::Symbol)
+    func === :delay_line! && return (:delay, :shift, 1)
+    func === :backward_connection! && return (:fb, :shift, 1)
+    func === :simple_cycle! && return (:cycle, nothing, nothing)
+    func === :reverse_simple_cycle! && return (:second_cycle, nothing, nothing)
+    func === :self_loop! && return (:selfloop, nothing, nothing)
+    func === :add_jumps! && return (:jump, :jump_size, 3)
+    func === :permute_matrix! && return (:permute, :permutation_matrix, nothing)
+    return throw(ArgumentError("@topology unknown building block `$func`"))
+end
+
+function _topology_kw(prefix::Symbol, param::Symbol)
+    param === :permutation_matrix && return param
+    startswith(String(param), String(prefix)) && return param
+    return Symbol(prefix, :_, param)
+end
+
+function _topology_weight_kw(prefix::Symbol)
+    prefix === :weight && return :weight
+    return Symbol(prefix, :_weight)
+end
+
+function _topology_kws(ex)
+    kws = Dict{Symbol, Any}()
+    Meta.isexpr(ex, :call) || return kws
+    for arg in ex.args[2:end]
+        params = Meta.isexpr(arg, :parameters) ? arg.args : (arg,)
+        for p in params
+            Meta.isexpr(p, :kw) || throw(
+                ArgumentError("@topology building blocks take keywords, got $p")
+            )
+            kws[p.args[1]] = p.args[2]
+        end
+    end
+    return kws
+end
+
+function _topology_entry(stmt)
+    prefix = nothing
+    if Meta.isexpr(stmt, :(=), 2) && stmt.args[1] isa Symbol
+        prefix, stmt = stmt.args
+    end
+    func = Meta.isexpr(stmt, :call) ? stmt.args[1] : stmt
+    func isa Symbol && endswith(String(func), "!") || throw(
+        ArgumentError("@topology expected a bang call, got $stmt")
+    )
+    return prefix, func, _topology_kws(stmt)
+end
+
+function _typed_kw(name, typ, default)
+    return Expr(:kw, Expr(:(::), name, typ), default)
+end
+
+function _topology_expand(name::Symbol, body)
+    stmts = Meta.isexpr(body, :block) ?
+        filter(s -> !(s isa LineNumberNode), body.args) : Any[body]
+    isempty(stmts) && throw(
+        ArgumentError("@topology requires at least one building block")
+    )
+
+    entries = map(_topology_entry, stmts)
+    n_signs = count(e -> e[2] !== :permute_matrix!, entries)
+    used = Set{Symbol}()
+    function claim(kw)
+        kw in used && throw(ArgumentError("@topology duplicate keyword `$kw`"))
+        push!(used, kw)
+        return kw
+    end
+
+    sig = Any[]
+    sign_kws = Any[]
+    calls = Expr[]
+    for (alias, func, kws) in entries
+        spec_prefix, extra, extra_default = _topology_spec(func)
+        weight_prefix = alias === nothing ? spec_prefix : alias
+        weighted = func !== :permute_matrix!
+        allowed = extra === nothing ? (:weight,) : (:weight, extra)
+        leftover = setdiff(keys(kws), allowed)
+        isempty(leftover) || throw(
+            ArgumentError("@topology `$func` got unsupported keyword $(join(leftover, ", "))")
+        )
+
+        args = Any[:rng, :reservoir_matrix]
+        if weighted
+            wkw = claim(_topology_weight_kw(weight_prefix))
+            wdef = get(kws, :weight, nothing)
+            wdef = wdef === nothing ? :(T(0.1f0)) :
+                wdef isa Number ? :(T($wdef)) : wdef
+            push!(sig, _typed_kw(wkw, :(Union{Number, AbstractVector}), wdef))
+            push!(args, :(T.($wkw)))
+        end
+        if extra !== nothing
+            ekw = claim(
+                alias === nothing ? _topology_kw(spec_prefix, extra) : extra
+            )
+            etype = extra === :permutation_matrix ?
+                :(Union{Nothing, AbstractMatrix}) : :Integer
+            push!(sig, _typed_kw(ekw, etype, get(kws, extra, extra_default)))
+            push!(args, ekw)
+        end
+        bang = getfield(@__MODULE__, func)
+        if weighted
+            if n_signs == 1
+                splat = :kwargs
+            else
+                splat = claim(Symbol(spec_prefix, :_kwargs))
+                push!(sign_kws, _typed_kw(splat, :NamedTuple, :(NamedTuple())))
+            end
+            push!(calls, Expr(:call, bang, Expr(:parameters, :($splat...)), args...))
+        else
+            push!(calls, Expr(:call, bang, args...))
+        end
+    end
+    push!(
+        sig,
+        _typed_kw(:radius, :(Union{AbstractFloat, Nothing}), :nothing),
+        _typed_kw(:return_sparse, :Bool, :false),
+    )
+    if n_signs == 1
+        push!(sig, :(kwargs...))
+    else
+        append!(sig, sign_kws)
+    end
+
+    primary = Expr(
+        :function,
+        Expr(
+            :where,
+            Expr(
+                :call, name, Expr(:parameters, sig...),
+                :(rng::$AbstractRNG), :(::Type{T}), :(dims::Integer...),
+            ),
+            :(T <: Number),
+        ),
+        quote
+            $throw_sparse_error(return_sparse)
+            $check_res_size(dims...)
+            reservoir_matrix = $DeviceAgnostic.zeros(rng, T, dims...)
+            $(calls...)
+            $scale_radius!(reservoir_matrix, radius)
+            return $return_init_as(Val(return_sparse), reservoir_matrix)
+        end,
+    )
+    return quote
+        Base.@__doc__ $primary
+        function $name(dims::Integer...; kwargs...)
+            return $name($Utils.default_rng(), Float32, dims...; kwargs...)
+        end
+        function $name(rng::$AbstractRNG, dims::Integer...; kwargs...)
+            return $name(rng, Float32, dims...; kwargs...)
+        end
+        function $name(::Type{T}, dims::Integer...; kwargs...) where {T <: Number}
+            return $name($Utils.default_rng(), T, dims...; kwargs...)
+        end
+        function $name(rng::$AbstractRNG; kwargs...)
+            return $PartialFunction.Partial{Nothing}($name, rng, kwargs)
+        end
+        function $name(::Type{T}; kwargs...) where {T <: Number}
+            return $PartialFunction.Partial{T}($name, nothing, kwargs)
+        end
+        function $name(
+                rng::$AbstractRNG, ::Type{T}; kwargs...
+            ) where {T <: Number}
+            return $PartialFunction.Partial{T}($name, rng, kwargs)
+        end
+        function $name(; kwargs...)
+            return $PartialFunction.Partial{Nothing}($name, nothing, kwargs)
+        end
+    end
+end
+
+@doc raw"""
+    @topology name begin
+        block!
+        alias = block!(; extra=default)
+    end
+
+Create a reservoir initializer from building blocks such as
+[`self_loop!`](@ref), [`simple_cycle!`](@ref), and [`delay_line!`](@ref).
+
+Each block has a `{prefix}_weight` keyword (default `0.1`). Extra arguments
+become keywords (`delay_shift`, `fb_shift`, `jump_size`). `radius` and
+`return_sparse` are always available. With more than one block, pass sign
+patterns as `{prefix}_kwargs`, for example
+`cycle_kwargs=(; signs=RandomSigns())`.
+
+`alias = block!` names the weight (`forward = delay_line!` → `forward_weight`,
+`weight = self_loop!` → `weight`). Sign kwargs stay on the block
+(`delay_kwargs`). An aliased extra keeps the bang name (`shift`); otherwise
+it is `{prefix}_{arg}` (`delay_shift`). Defaults: `self_loop!` → `selfloop`,
+`simple_cycle!` → `cycle`, `delay_line!` → `delay`,
+`backward_connection!` → `fb`, `add_jumps!` → `jump`,
+`reverse_simple_cycle!` → `second_cycle`, `permute_matrix!` → `permute`.
+
+```jldoctest
+julia> @topology my_cycle begin
+           self_loop!
+           simple_cycle!
+       end;
+
+julia> my_cycle(5, 5)
+5×5 Matrix{Float32}:
+ 0.1  0.0  0.0  0.0  0.1
+ 0.1  0.1  0.0  0.0  0.0
+ 0.0  0.1  0.1  0.0  0.0
+ 0.0  0.0  0.1  0.1  0.0
+ 0.0  0.0  0.0  0.1  0.1
+```
+"""
+macro topology(name, body)
+    name isa Symbol || throw(
+        ArgumentError("@topology first argument must be an identifier, got $name")
+    )
+    return esc(_topology_expand(name, body))
+end

--- a/test/inits_topology_tests.jl
+++ b/test/inits_topology_tests.jl
@@ -1,0 +1,121 @@
+using Test
+using LinearAlgebra
+using Random
+using ReservoirComputing
+
+@topology topology_selfloop_cycle begin
+    self_loop!
+    simple_cycle!
+end
+@topology topology_forward begin
+    forward = delay_line!(shift = 2)
+end
+@topology topology_delayline_backward begin
+    delay_line!
+    backward_connection!
+end
+@topology topology_perm begin
+    weight = self_loop!
+    permute_matrix!
+end
+@topology topology_cycle_jumps begin
+    simple_cycle!
+    add_jumps!
+end
+@topology topology_true_doublecycle begin
+    simple_cycle!
+    reverse_simple_cycle!
+end
+@topology topology_selfloop_forward begin
+    self_loop!
+    forward = delay_line!(shift = 2)
+end
+@topology topology_heavy_cycle begin
+    simple_cycle!(weight = 0.5)
+end
+@topology topology_delay begin
+    delay_line!
+end
+@topology topology_cycle begin
+    simple_cycle!
+end
+@topology topology_selfloop_delayline_backward begin
+    self_loop!
+    delay_line!
+    backward_connection!(shift = 2)
+end
+
+@testset "@topology" begin
+    @test size(topology_selfloop_cycle(16, 16)) == (16, 16)
+    @test eltype(topology_selfloop_cycle(Float64, 8, 8)) == Float64
+    @test eltype(topology_selfloop_cycle(Xoshiro(1))(Float32, 8, 8)) == Float32
+
+    @test topology_selfloop_cycle(5, 5) == selfloop_cycle(5, 5)
+    @test topology_selfloop_cycle(
+        5, 5; cycle_weight = -0.2, selfloop_weight = 0.5
+    ) == selfloop_cycle(5, 5; cycle_weight = -0.2, selfloop_weight = 0.5)
+    @test topology_selfloop_cycle(
+        MersenneTwister(123), 5, 5; cycle_kwargs = (; signs = RandomSigns())
+    ) == selfloop_cycle(
+        MersenneTwister(123), 5, 5; cycle_kwargs = (; signs = RandomSigns())
+    )
+    @test topology_forward(5, 5) == forward_connection(5, 5)
+    @test topology_delayline_backward(5, 5; delay_shift = 3, fb_shift = 2) ==
+        delayline_backward(5, 5; delay_shift = 3, fb_shift = 2)
+    @test topology_heavy_cycle(4, 4) == simple_cycle(4, 4; cycle_weight = 0.5)
+    @test topology_cycle_jumps(5, 5) == cycle_jumps(5, 5)
+    @test topology_cycle_jumps(5, 5; jump_size = 2) ==
+        cycle_jumps(5, 5; jump_size = 2)
+    @test topology_true_doublecycle(5, 5) == true_doublecycle(5, 5)
+    @test topology_selfloop_forward(5, 5) == selfloop_forwardconnection(5, 5)
+    @test topology_selfloop_forward(
+        5, 5; forward_weight = 0.5f0, selfloop_weight = 0.99f0
+    ) == selfloop_forwardconnection(
+        5, 5; forward_weight = 0.5f0, selfloop_weight = 0.99f0
+    )
+    @test topology_selfloop_forward(
+        5, 5; delay_kwargs = (; signs = IrrationalDigitSigns())
+    ) == selfloop_forwardconnection(
+        5, 5; delay_kwargs = (; signs = IrrationalDigitSigns())
+    )
+    @test topology_perm(MersenneTwister(123), 5, 5) ==
+        permutation_init(MersenneTwister(123), 5, 5)
+    @test topology_perm(MersenneTwister(123), 5, 5; weight = 0.99f0) ==
+        permutation_init(MersenneTwister(123), 5, 5; weight = 0.99f0)
+    @test topology_delay(5, 5) == delay_line(5, 5)
+    @test topology_delay(5, 5; delay_shift = 3, signs = IrrationalDigitSigns()) ==
+        delay_line(5, 5; delay_shift = 3, signs = IrrationalDigitSigns())
+    @test topology_cycle(5, 5; cycle_weight = 0.99) ==
+        simple_cycle(5, 5; cycle_weight = 0.99)
+    @test topology_selfloop_delayline_backward(5, 5) ==
+        selfloop_delayline_backward(5, 5)
+    cw = Float32[0.2, 0.4, 0.6, 0.8, 1.0]
+    sw = -Float32[0.1, 0.3, 0.5, 0.7, 0.9]
+    @test topology_selfloop_cycle(5, 5; cycle_weight = cw, selfloop_weight = sw) ==
+        selfloop_cycle(5, 5; cycle_weight = cw, selfloop_weight = sw)
+    @test isapprox(
+        maximum(abs.(eigvals(topology_selfloop_cycle(8, 8; radius = 1.0)))),
+        1.0; atol = 1.0e-5
+    )
+    @test_throws DimensionMismatch topology_selfloop_cycle(3, 4)
+
+    ps, = setup(Xoshiro(0), ESNCell(2 => 8; init_reservoir = topology_selfloop_cycle))
+    @test ps.reservoir_matrix == topology_selfloop_cycle(8, 8)
+    ps_esn, = setup(
+        Xoshiro(0), ESN(2, 8, 1; init_reservoir = topology_selfloop_cycle)
+    )
+    @test ps_esn.reservoir.reservoir_matrix == topology_selfloop_cycle(8, 8)
+
+    @test_throws ArgumentError @macroexpand @topology empty_topology begin
+    end
+    @test_throws ArgumentError @macroexpand @topology (10, 10) begin
+        self_loop!
+    end
+    @test_throws ArgumentError @macroexpand @topology bad_block begin
+        not_a_block!
+    end
+    @test_throws ArgumentError @macroexpand @topology duplicate_prefix begin
+        delay_line!
+        delay_line!
+    end
+end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/ColPrac)
- [x] Any new documentation only uses public API

## Additional context

`@topology` builds a reservoir initializer from the existing bang mutators (`self_loop!`, `simple_cycle!`, `delay_line!`, ...). Same `[rng]` / `[T]` / `dims` calling convention as the handwritten inits, including partial application. Existing named inits are unchanged.

```julia
@topology my_cycle begin
    self_loop!
    simple_cycle!
end

my_cycle(100, 100)
ESNCell(2 => 100; init_reservoir = my_cycle(; cycle_weight = 0.2))
```

Closes #350