### PR TITLE
Drop x86 CI lane (BFloat16s i686)

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -2,12 +2,14 @@
 versions = ["lts", "1", "pre"]
 os = ["ubuntu-latest", "windows-latest", "macos-latest"]
 
-["Core 32-bit"]
-group = "Core"
-versions = ["1"]
-os = ["ubuntu-latest"]
-arch = "x86"
-
+# Core 32-bit dropped: NNlib→BFloat16s LLVM soft-promote fails on i686
+# Re-enable when JuliaMath/BFloat16s works on 32-bit.
+# ["Core 32-bit"]
+# group = "Core"
+# versions = ["1"]
+# os = ["ubuntu-latest"]
+# arch = "x86"
+# 
 [Layers]
 versions = ["lts", "1", "pre"]
 os = ["ubuntu-latest", "windows-latest", "macos-latest"]


### PR DESCRIPTION
## Summary
- Drop the x86 / 32-bit CI lane until BFloat16s works on i686 (LLVM soft-promote fatal).
- Same class of failure as LineSearch / DataDrivenDiffEq lane drops.

## Test plan
- [ ] No `ubuntu-latest, x86` job in Tests
- [ ] Remaining lanes unchanged
