### PR TITLE
feat(esn): add feedback weight to ESNCell

### DIFF
--- a/docs/src/tutorials/train.md
+++ b/docs/src/tutorials/train.md
@@ -25,6 +25,22 @@ ps, st = train(model, input_data, target_data, ps, st;
 `objective` chooses what to fit (here ridge). `solver` chooses how to solve it;
 omitting `solver` uses [`QRFactorization`](@ref).
 
+## Output feedback
+
+An [`ESN`](@ref) / [`ESNCell`](@ref) with `use_feedback=true` injects the
+previous output through `W_fb`. Training uses teacher forcing: pass
+`(train_data, teacher_data)`, or pass only `train_data` and the teacher is
+`target_data` shifted by one step (zeros at the first column).
+
+```@example training
+fb_model = ESN(3, 100, 5; use_feedback = true)
+ps_fb, st_fb = setup(rng, fb_model)
+ps_fb, st_fb = train(fb_model, input_data, target_data, ps_fb, st_fb)
+```
+
+After training, [`predict`](@ref) feeds the model's own previous output through
+`W_fb` while still consuming the driving input.
+
 ```@example training
 ps, st = train(model, input_data, target_data, ps, st;
     objective = RidgeRegression())

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -1,5 +1,8 @@
 const BoolType = Union{StaticBool, Bool, Val{true}, Val{false}}
 const InputType = Tuple{<:AbstractArray, Tuple{<:AbstractArray}}
+const FeedbackInputType = Tuple{
+    Tuple{<:AbstractArray, <:AbstractArray}, Tuple{<:AbstractArray},
+}
 const IntegerType = Union{Integer, StaticInt}
 const RCFields = (:cells, :state_modifiers, :readout)
 

--- a/src/layers/esn_cell.jl
+++ b/src/layers/esn_cell.jl
@@ -49,9 +49,11 @@ abstract type AbstractEchoStateNetworkCell <: AbstractReservoirRecurrentCell end
     ESNCell(in_dims => out_dims, [activation];
         use_bias=false, init_bias=rand32,
         init_reservoir=rand_sparse, init_input=scaled_rand,
-        init_state=randn32, leak_coefficient=1.0)
+        init_state=randn32, leak_coefficient=1.0,
+        use_feedback=false, feedback_dims=0, init_feedback=scaled_rand)
 
-Echo State Network (ESN) recurrent cell with optional leaky integration.
+Echo State Network (ESN) recurrent cell with optional leaky integration
+and optional output feedback [Jaeger2004](@cite).
 
 ## Equations
 
@@ -59,9 +61,16 @@ Echo State Network (ESN) recurrent cell with optional leaky integration.
 \begin{aligned}
     \mathbf{x}(t) &= (1-\alpha)\, \mathbf{x}(t-1)
         + \alpha\, \phi\!\left(\mathbf{W}_{\text{in}}\, \mathbf{u}(t)
-        + \mathbf{W}_r\, \mathbf{x}(t-1) + \mathbf{b} \right)
+        + \mathbf{W}_r\, \mathbf{x}(t-1)
+        + \mathbf{W}_{\mathrm{fb}}\, \mathbf{y}(t-1)
+        + \mathbf{b} \right)
 \end{aligned}
 ```
+
+The \(\mathbf{W}_{\mathrm{fb}}\mathbf{y}(t-1)\) term is included only when
+`use_feedback=true`. During training, \(\mathbf{y}\) is the teacher signal;
+after training it is the model's previous output.
+
 ## Arguments
 
   - `in_dims`: Input dimension.
@@ -81,6 +90,11 @@ Echo State Network (ESN) recurrent cell with optional leaky integration.
     state is not provided. Default is `randn32`.
   - leak_coefficient: Leak rate `α ∈ (0,1]`. Can be a scalar (uniform leak)
     or a vector of size `out_dims` (heterogeneous leak rates). Default: `1.0`.
+  - `use_feedback`: Whether to include output feedback `W_fb`. Default: `false`.
+  - `feedback_dims`: Width of the feedback signal (readout output dimension).
+    Required and must be positive when `use_feedback=true`. Default: `0`.
+  - `init_feedback`: Initializer for `W_fb`. Used only if `use_feedback=true`.
+    Default is [`scaled_rand`](@ref).
 
 ## Inputs
 
@@ -88,8 +102,11 @@ Echo State Network (ESN) recurrent cell with optional leaky integration.
     A fresh state is created via `init_state`; the call is forwarded to Case 2.
   - **Case 2:** `(x, (h,))` where `h :: AbstractArray (out_dims, batch)`
     Computes the update and returns the new state.
+  - **Case 3:** `((x, y), (h,))` when `use_feedback=true`, with
+    `y :: AbstractArray (feedback_dims, batch)` the previous output
+    (or teacher). A first call `(x, y)` with no carry is also accepted.
 
-In both cases, the forward returns `((h_new, (h_new,)), st_out)` where `st_out`
+In all cases, the forward returns `((h_new, (h_new,)), st_out)` where `st_out`
 contains any updated internal state.
 
 ## Returns
@@ -104,6 +121,8 @@ Created by `initialparameters(rng, esn)`:
   - `input_matrix :: (out_dims × in_dims)` — `W_in`
   - `reservoir_matrix :: (out_dims × out_dims)` — `W_res`
   - `bias :: (out_dims,)` — present only if `use_bias=true`
+  - `feedback_matrix :: (out_dims × feedback_dims)` — `W_fb`,
+    present only if `use_feedback=true`
 
 ## States
 
@@ -118,10 +137,12 @@ Created by `initialstates(rng, esn)`:
     init_bias
     init_reservoir
     init_input
-    #init_feedback::F
+    init_feedback
     init_state
     leak_coefficient
+    feedback_dims <: IntegerType
     use_bias <: StaticBool
+    use_feedback <: StaticBool
 end
 
 function ESNCell(
@@ -129,7 +150,10 @@ function ESNCell(
         activation = tanh_fast; use_bias::BoolType = False(), init_bias = zeros32,
         init_reservoir = rand_sparse, init_input = scaled_rand,
         init_state = randn32,
-        leak_coefficient::Union{AbstractFloat, AbstractVector} = 1.0
+        leak_coefficient::Union{AbstractFloat, AbstractVector} = 1.0,
+        use_feedback::BoolType = False(),
+        feedback_dims::IntegerType = 0,
+        init_feedback = scaled_rand
     )
 
     if isa(leak_coefficient, AbstractVector)
@@ -141,9 +165,20 @@ function ESNCell(
         )
     end
 
+    use_fb = static(use_feedback)
+    if known(use_fb)
+        Int(feedback_dims) > 0 || throw(
+            ArgumentError(
+                "feedback_dims must be positive when use_feedback=true, " *
+                    "got $feedback_dims"
+            )
+        )
+    end
+
     return ESNCell(
         activation, in_dims, out_dims, init_bias, init_reservoir,
-        init_input, init_state, leak_coefficient, static(use_bias)
+        init_input, init_feedback, init_state, leak_coefficient,
+        feedback_dims, static(use_bias), use_fb
     )
 end
 
@@ -154,6 +189,16 @@ function initialparameters(rng::AbstractRNG, esn::AbstractEchoStateNetworkCell)
     )
     if has_bias(esn)
         ps = merge(ps, (bias = esn.init_bias(rng, esn.out_dims),))
+    end
+    if has_feedback(esn)
+        ps = merge(
+            ps,
+            (
+                feedback_matrix = esn.init_feedback(
+                    rng, esn.out_dims, esn.feedback_dims
+                ),
+            ),
+        )
     end
     return ps
 end
@@ -172,15 +217,44 @@ function (esn::AbstractEchoStateNetworkCell)(inp::AbstractArray, ps, st::NamedTu
     return esn((inp, (hidden_state,)), ps, merge(st, (; rng)))
 end
 
-function (esn::ESNCell)((inp, (hidden_state,))::InputType, ps, st::NamedTuple)
+function (esn::ESNCell)(
+        inp::Tuple{<:AbstractArray, <:AbstractArray}, ps, st::NamedTuple
+    )
+    rng = replicate(st.rng)
+    hidden_state = init_hidden_state(rng, esn, first(inp))
+    return esn((inp, (hidden_state,)), ps, merge(st, (; rng)))
+end
+
+function __esncell_step(esn::ESNCell, inp, hidden_state, ps, st, feedback)
     T = eltype(inp)
     bias = safe_getproperty(ps, Val(:bias))
-    win_inp = dense_bias(ps.input_matrix, inp, nothing)
-    w_state = dense_bias(ps.reservoir_matrix, hidden_state, bias)
-    candidate_h = esn.activation.(win_inp .+ w_state)
+    preact = dense_bias(ps.input_matrix, inp, nothing) .+
+        dense_bias(ps.reservoir_matrix, hidden_state, bias)
+    if feedback !== nothing
+        preact = preact .+ dense_bias(ps.feedback_matrix, feedback, nothing)
+    end
+    candidate_h = esn.activation.(preact)
     lc = __format_leak(T, esn.leak_coefficient)
     h_new = __one_minus_leak(T, lc) .* hidden_state .+ lc .* candidate_h
     return (h_new, (h_new,)), st
+end
+
+function (esn::ESNCell)((inp, (hidden_state,))::InputType, ps, st::NamedTuple)
+    has_feedback(esn) && throw(
+        ArgumentError(
+            "ESNCell with use_feedback=true expects input (u, y_prev), got a single array"
+        )
+    )
+    return __esncell_step(esn, inp, hidden_state, ps, st, nothing)
+end
+
+function (esn::ESNCell)(
+        ((inp, feedback), (hidden_state,))::FeedbackInputType, ps, st::NamedTuple
+    )
+    has_feedback(esn) || throw(
+        ArgumentError("ESNCell received (u, y_prev) but use_feedback=false")
+    )
+    return __esncell_step(esn, inp, hidden_state, ps, st, feedback)
 end
 
 function __format_leak(::Type{T}, leak::Number) where {T <: Number}
@@ -205,5 +279,8 @@ function Base.show(io::IO, esn::ESNCell)
         print(io, ", leak_coefficient=$(esn.leak_coefficient)")
     end
     has_bias(esn) || print(io, ", use_bias=false")
+    if has_feedback(esn)
+        print(io, ", use_feedback=true, feedback_dims=$(esn.feedback_dims)")
+    end
     return print(io, ")")
 end

--- a/src/layers/eusn_cell.jl
+++ b/src/layers/eusn_cell.jl
@@ -72,7 +72,6 @@ Created by `initialstates(rng, esn)`:
     init_bias
     init_reservoir
     init_input
-    #init_feedback::F
     init_state
     leak_coefficient
     diffusion

--- a/src/layers/lux_layers.jl
+++ b/src/layers/lux_layers.jl
@@ -231,6 +231,14 @@ function has_bias(l::AbstractLuxLayer)
     return ifelse(res === nothing, false, res)
 end
 
+function has_feedback(l::AbstractLuxLayer)
+    flag = getproperty(l, Val(:use_feedback))
+    flag === nothing && return false
+    res = known(flag)
+    return ifelse(res === nothing, false, res)
+end
+has_feedback(::Nothing) = false
+
 @generated function getproperty(x::X, ::KnownSymbolType{v}) where {X, v}
     if hasfield(X, v)
         return :(getfield(x, v))

--- a/src/models/esn.jl
+++ b/src/models/esn.jl
@@ -17,6 +17,7 @@ Echo State Network [Jaeger2004](@cite).
 \begin{aligned}
     \mathbf{x}(t) &= (1-\alpha)\, \mathbf{x}(t-1) + \alpha\, \phi\!\left(
         \mathbf{W}_{\text{in}}\, \mathbf{u}(t) + \mathbf{W}_r\, \mathbf{x}(t-1)
+        + \mathbf{W}_{\mathrm{fb}}\, \mathbf{y}(t-1)
         + \mathbf{b} \right) \\
     \mathbf{z}(t) &= \mathrm{Mods}\!\left(\mathbf{x}(t)\right) \\
     \mathbf{y}(t) &= \rho\!\left(
@@ -24,6 +25,10 @@ Echo State Network [Jaeger2004](@cite).
         + \mathbf{b}_{\text{out}} \right)
 \end{aligned}
 ```
+
+The \(\mathbf{W}_{\mathrm{fb}}\mathbf{y}(t-1)\) term is included only when
+`use_feedback=true`. Train with teacher forcing; `predict` then feeds the
+previous model output back through `W_fb`.
 
 ## Arguments
 
@@ -45,6 +50,10 @@ Reservoir (passed to [`ESNCell`](@ref)):
   - `init_state`: Initializer used when an external state is not provided.
     Default: `randn32`.
   - `use_bias`: Whether the reservoir uses a bias term. Default: `false`.
+  - `use_feedback`: Whether the reservoir uses output feedback `W_fb`.
+    Default: `false`. When `true`, `feedback_dims` is set to `out_dims`.
+  - `init_feedback`: Initializer for `W_fb`. Used only if `use_feedback=true`.
+    Default: [`scaled_rand`](@ref).
 
 Composition:
 
@@ -70,6 +79,8 @@ Composition:
       - `input_matrix :: (res_dims × in_dims)` — `W_in`
       - `reservoir_matrix :: (res_dims × res_dims)` — `W_res`
       - `bias :: (res_dims,)` — present only if `use_bias=true`
+      - `feedback_matrix :: (res_dims × out_dims)` — `W_fb`,
+        present only if `use_feedback=true`
   - `state_modifiers` — a `Tuple` with parameters for each modifier layer (may be empty).
   - `readout` — parameters of [`LinearReadout`](@ref), typically:
       - `weight :: (out_dims × res_dims)` — `W_out`
@@ -100,7 +111,9 @@ function ESN(
         readout_in_dims = nothing,
         kwargs...
     )
-    cell = StatefulLayer(ESNCell(in_dims => res_dims, activation; kwargs...))
+    cell = StatefulLayer(
+        ESNCell(in_dims => res_dims, activation; kwargs..., feedback_dims = out_dims)
+    )
     mods_tuple = state_modifiers isa Tuple || state_modifiers isa AbstractVector ?
         Tuple(state_modifiers) : (state_modifiers,)
     mods = __wrap_layers(mods_tuple)

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -39,11 +39,15 @@ sequence.
 
 - Feeds each column of `data` as input; the model state is threaded across time,
   and an output is produced for each input column.
+- If the reservoir has output feedback, previous model outputs are fed back
+  through `W_fb`. Pass `(data, teacher_data)` to teacher-force that feedback
+  instead.
 
 ### Arguments
 
 - `rc`: The reservoir chain / model.
-- `data`: Input sequence of shape `(in_dims, T)` (columns are time).
+- `data`: Input sequence of shape `(in_dims, T)` (columns are time), or
+  `(data, teacher_data)` when forcing output feedback.
 - `ps`: Model parameters.
 - `st`: Model states.
 
@@ -128,6 +132,15 @@ function predict(rc::AbstractReservoirComputer, data::AbstractMatrix, ps, st)
     return __predict(res, rc, data, ps, st)
 end
 
+function predict(
+        rc::AbstractReservoirComputer,
+        data::Tuple{<:AbstractMatrix, <:AbstractMatrix},
+        ps, st
+    )
+    res = hasfield(typeof(rc), :reservoir) ? rc.reservoir : nothing
+    return __predict(res, rc, data, ps, st)
+end
+
 function __predict(
         ::AbstractSciMLProblemReservoir,
         ::AbstractReservoirComputer, ::Integer, ::Any, ::Any;
@@ -157,10 +170,48 @@ function __predict(
         ::Any, rc::AbstractReservoirComputer, steps::Integer, ps, st;
         initialdata::AbstractVector
     )
+    __has_output_feedback(rc) && throw(
+        ArgumentError(
+            "autoregressive predict is not defined for models with output " *
+                "feedback; use predict(rc, data, ps, st) with a driving input"
+        )
+    )
     return __autoregressive_predict(rc, steps, ps, st, initialdata)
 end
 
+function __zero_feedback(data::AbstractMatrix, fb_dims::Integer)
+    y0 = similar(data, fb_dims)
+    fill!(y0, zero(eltype(data)))
+    return y0
+end
+
+function __feedback_predict(rc, data, ps, st, teacher)
+    __require_nonempty_data(data, "predict")
+    n_samples = size(data, 2)
+    fb_dims = Int(__reservoir_cell(rc).feedback_dims)
+    y_fb = if teacher === nothing
+        __zero_feedback(data, fb_dims)
+    else
+        __validate_feedback_data(rc, data, teacher, "predict")
+        teacher[:, 1]
+    end
+
+    first_output, st = apply(rc, (data[:, 1], y_fb), ps, st)
+    __require_closed_loop_dimension(first_output, fb_dims, 1)
+    outputs = similar(first_output, size(first_output, 1), n_samples)
+    outputs[:, 1] .= first_output
+
+    for t in 2:n_samples
+        y_fb = teacher === nothing ? outputs[:, t - 1] : teacher[:, t]
+        current_output, st = apply(rc, (data[:, t], y_fb), ps, st)
+        __require_closed_loop_dimension(current_output, fb_dims, t)
+        outputs[:, t] .= current_output
+    end
+    return outputs, st
+end
+
 function __predict(::Any, rc::AbstractReservoirComputer, data::AbstractMatrix, ps, st)
+    __has_output_feedback(rc) && return __feedback_predict(rc, data, ps, st, nothing)
     __require_nonempty_data(data, "predict")
     n_samples = size(data, 2)
 
@@ -174,4 +225,23 @@ function __predict(::Any, rc::AbstractReservoirComputer, data::AbstractMatrix, p
         outputs[:, idx] .= current_output
     end
     return outputs, st
+end
+
+function __predict(
+        ::Any, rc::AbstractReservoirComputer,
+        data::Tuple{<:AbstractMatrix, <:AbstractMatrix}, ps, st
+    )
+    train_data, teacher_data = data
+    return __feedback_predict(rc, train_data, ps, st, teacher_data)
+end
+
+function __predict(
+        ::AbstractSciMLProblemReservoir,
+        ::AbstractReservoirComputer,
+        ::Tuple, ::Any, ::Any
+    )
+    return error(
+        "Teacher-forced `predict(rc, (data, teacher), ps, st)` for a " *
+            "`SciMLProblemReservoir` requires the `RCODEReservoirExt` extension."
+    )
 end

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -238,7 +238,7 @@ end
 function __predict(
         ::AbstractSciMLProblemReservoir,
         ::AbstractReservoirComputer,
-        ::Tuple, ::Any, ::Any
+        ::Tuple{<:AbstractMatrix, <:AbstractMatrix}, ::Any, ::Any
     )
     return error(
         "Teacher-forced `predict(rc, (data, teacher), ps, st)` for a " *

--- a/src/reservoircomputer.jl
+++ b/src/reservoircomputer.jl
@@ -140,9 +140,9 @@ end
 end
 
 function __reservoir_cell(rc)
-    hasfield(typeof(rc), :reservoir) || return nothing
-    res = getfield(rc, :reservoir)
-    return hasfield(typeof(res), :cell) ? getfield(res, :cell) : nothing
+    res = getproperty(rc, Val(:reservoir))
+    res === nothing && return nothing
+    return getproperty(res, Val(:cell))
 end
 
 __has_output_feedback(rc) = has_feedback(__reservoir_cell(rc))
@@ -211,12 +211,13 @@ function collectstates(
         data::Tuple{<:AbstractMatrix, <:AbstractMatrix},
         ps, st::NamedTuple
     )
-    hasfield(typeof(rc), :reservoir) || throw(
+    res = getproperty(rc, Val(:reservoir))
+    res === nothing && throw(
         ArgumentError(
             "teacher data requires a reservoir with use_feedback=true"
         )
     )
-    return __collectstates(rc.reservoir, rc, data, ps, st)
+    return __collectstates(res, rc, data, ps, st)
 end
 
 function __collectstates(

--- a/src/reservoircomputer.jl
+++ b/src/reservoircomputer.jl
@@ -132,10 +132,55 @@ function __resolve_readout_in_dims(
     return Int(readout_in_dims)
 end
 
+@inline __driving_input(inp::AbstractArray) = inp
+@inline function __driving_input(
+        (inp, _)::Tuple{<:AbstractArray, <:AbstractArray}
+    )
+    return inp
+end
+
+function __reservoir_cell(rc)
+    hasfield(typeof(rc), :reservoir) || return nothing
+    res = getfield(rc, :reservoir)
+    return hasfield(typeof(res), :cell) ? getfield(res, :cell) : nothing
+end
+
+__has_output_feedback(rc) = has_feedback(__reservoir_cell(rc))
+
+function __require_output_feedback(rc)
+    __has_output_feedback(rc) || throw(
+        ArgumentError(
+            "teacher data requires a reservoir with use_feedback=true"
+        )
+    )
+    return nothing
+end
+
+function __validate_feedback_data(rc, train_data, teacher_data, context)
+    __require_nonempty_data(train_data, context)
+    __require_output_feedback(rc)
+    n_samples = size(train_data, 2)
+    n_teacher = size(teacher_data, 2)
+    n_samples == n_teacher || throw(
+        DimensionMismatch(
+            "train data has $n_samples samples, teacher data has $n_teacher"
+        )
+    )
+    fb_dims = Int(__reservoir_cell(rc).feedback_dims)
+    size(teacher_data, 1) == fb_dims || throw(
+        DimensionMismatch(
+            "teacher data has $(size(teacher_data, 1)) rows, expected " *
+                "feedback_dims=$fb_dims"
+        )
+    )
+    return nothing
+end
+
 function __partial_apply(rc::AbstractReservoirComputer, inp, ps, st)
     out, st_res = apply(rc.reservoir, inp, ps.reservoir, st.reservoir)
     out, st_mods = __apply_state_modifiers(
-        rc.state_modifiers, out, inp, ps.state_modifiers, st.state_modifiers
+        rc.state_modifiers, out, __driving_input(inp),
+        ps.state_modifiers, st.state_modifiers
     )
     return out, (reservoir = st_res, state_modifiers = st_mods)
 end
@@ -146,8 +191,30 @@ function (rc::AbstractReservoirComputer)(inp, ps, st)
     return out, merge(new_st, (readout = st_ro,))
 end
 
+@doc raw"""
+    collectstates(rc::AbstractReservoirComputer, data, ps, st)
+
+Harvest reservoir features over the columns of `data`.
+
+When the reservoir has output feedback (`use_feedback=true`), `data` must be
+`(train_data, teacher_data)` with matching column counts. Column `t` of
+`teacher_data` is the feedback \(\mathbf{y}(t-1)\) used with input column `t`.
+"""
 function collectstates(
         rc::AbstractReservoirComputer, data::AbstractMatrix, ps, st::NamedTuple
+    )
+    return __collectstates(rc.reservoir, rc, data, ps, st)
+end
+
+function collectstates(
+        rc::AbstractReservoirComputer,
+        data::Tuple{<:AbstractMatrix, <:AbstractMatrix},
+        ps, st::NamedTuple
+    )
+    hasfield(typeof(rc), :reservoir) || throw(
+        ArgumentError(
+            "teacher data requires a reservoir with use_feedback=true"
+        )
     )
     return __collectstates(rc.reservoir, rc, data, ps, st)
 end
@@ -163,17 +230,13 @@ function __collectstates(
     )
 end
 
-function __collectstates(
-        _, rc::AbstractReservoirComputer, data::AbstractMatrix, ps, st::NamedTuple
-    )
-    __require_nonempty_data(data, "collectstates")
+function __harvest_states(rc, cols, like, ps, st)
     newst = st
-    nsteps = size(data, 2)
-    cols = eachcol(data)
+    nsteps = size(like, 2)
     x1 = first(cols)
     current_state, partial_st = __partial_apply(rc, x1, ps, newst)
     state_dims = size(current_state, 1)
-    states = similar(data, state_dims, nsteps)
+    states = similar(like, state_dims, nsteps)
     states[:, 1] .= current_state
     newst = merge(partial_st, (readout = newst.readout,))
     for (idx, inp) in Base.Iterators.drop(Base.enumerate(cols), 1)
@@ -181,8 +244,31 @@ function __collectstates(
         states[:, idx] .= current_state
         newst = merge(partial_st, (readout = newst.readout,))
     end
-
     return states, newst
+end
+
+function __collectstates(
+        _, rc::AbstractReservoirComputer, data::AbstractMatrix, ps, st::NamedTuple
+    )
+    __require_nonempty_data(data, "collectstates")
+    __has_output_feedback(rc) && throw(
+        ArgumentError(
+            "collectstates for a model with output feedback requires teacher " *
+                "data; pass (train_data, teacher_data)"
+        )
+    )
+    return __harvest_states(rc, eachcol(data), data, ps, st)
+end
+
+function __collectstates(
+        _, rc::AbstractReservoirComputer,
+        data::Tuple{<:AbstractMatrix, <:AbstractMatrix}, ps, st::NamedTuple
+    )
+    train_data, teacher_data = data
+    __validate_feedback_data(rc, train_data, teacher_data, "collectstates")
+    return __harvest_states(
+        rc, zip(eachcol(train_data), eachcol(teacher_data)), train_data, ps, st
+    )
 end
 
 __set_readout_weight(ps_readout::NamedTuple, wro) = merge(ps_readout, (; weight = wro))

--- a/src/train.jl
+++ b/src/train.jl
@@ -179,7 +179,7 @@ function __train_ridge(
     )
     design, rhs = __ridge_augmented_system(objective, states, targets)
     solution = try
-        solve(LinearProblem(design, rhs), solver; kwargs...)
+        solve(LinearProblem(design, rhs), solver; verbose = false, kwargs...)
     catch err
         err isa DimensionMismatch || rethrow()
         throw(
@@ -191,10 +191,12 @@ function __train_ridge(
             )
         )
     end
-    successful_retcode(solution) || throw(
+    successful_retcode(solution) && return Matrix(solution.u')
+    # LinearSolve QR NoPivot reports Failure on rank-deficient least squares.
+    solver isa LinearSolveQRFactorization || throw(
         ArgumentError("solver $(typeof(solver)) failed to solve the ridge regression system")
     )
-    return Matrix(solution.u')
+    return Matrix((qr(design) \ rhs)')
 end
 
 function __shift_teacher(target_data::AbstractMatrix)
@@ -206,7 +208,6 @@ function __shift_teacher(target_data::AbstractMatrix)
 end
 
 function __train_collect_args(rc, train_data::AbstractMatrix, target_data)
-    __has_output_feedback(rc) || return train_data
     size(target_data, 2) == size(train_data, 2) || throw(
         DimensionMismatch(
             "train data has $(size(train_data, 2)) samples, " *
@@ -222,11 +223,25 @@ function __train_collect_args(rc, train_data::AbstractMatrix, target_data)
     return (train_data, __shift_teacher(target_data))
 end
 
-function __train_collect_args(
-        rc, train_data::Tuple{<:AbstractMatrix, <:AbstractMatrix}, _
+function __train_fit(
+        rc, train_data, target_data, ps, st;
+        objective = RidgeRegression(0.0),
+        solver = nothing,
+        washout::Integer = 0,
+        return_states::Bool = false,
+        kwargs...
     )
-    __require_output_feedback(rc)
-    return train_data
+    raw_states, st_after = collectstates(rc, train_data, ps, st)
+    states_wo,
+        targets_wo = washout > 0 ? __apply_washout(raw_states, target_data, washout) :
+        (raw_states, target_data)
+    output_matrix = if isnothing(solver)
+        __fit_readout(objective, states_wo, targets_wo; kwargs...)
+    else
+        __fit_readout(objective, states_wo, targets_wo; solver = solver, kwargs...)
+    end
+    ps2, st_after = addreadout!(rc, output_matrix, ps, st_after)
+    return return_states ? ((ps2, st_after), states_wo) : (ps2, st_after)
 end
 
 @doc raw"""
@@ -266,26 +281,39 @@ and returns new parameters and states (inputs `ps` / `st` are not mutated).
   - `(ps, st)`, or `((ps, st), states)` if `return_states=true`.
 """
 function train(
-        rc, train_data, target_data, ps, st;
+        rc, train_data::AbstractMatrix, target_data, ps, st;
         objective = RidgeRegression(0.0),
         solver = nothing,
         washout::Integer = 0,
         return_states::Bool = false,
         kwargs...
     )
-    raw_states, st_after = collectstates(
-        rc, __train_collect_args(rc, train_data, target_data), ps, st
-    )
-    states_wo,
-        targets_wo = washout > 0 ? __apply_washout(raw_states, target_data, washout) :
-        (raw_states, target_data)
-    output_matrix = if isnothing(solver)
-        __fit_readout(objective, states_wo, targets_wo; kwargs...)
-    else
-        __fit_readout(objective, states_wo, targets_wo; solver = solver, kwargs...)
+    if __has_output_feedback(rc)
+        return train(
+            rc, __train_collect_args(rc, train_data, target_data),
+            target_data, ps, st;
+            objective, solver, washout, return_states, kwargs...
+        )
     end
-    ps2, st_after = addreadout!(rc, output_matrix, ps, st_after)
-    return return_states ? ((ps2, st_after), states_wo) : (ps2, st_after)
+    return __train_fit(
+        rc, train_data, target_data, ps, st;
+        objective, solver, washout, return_states, kwargs...
+    )
+end
+
+function train(
+        rc, train_data::Tuple{<:AbstractMatrix, <:AbstractMatrix}, target_data, ps, st;
+        objective = RidgeRegression(0.0),
+        solver = nothing,
+        washout::Integer = 0,
+        return_states::Bool = false,
+        kwargs...
+    )
+    __require_output_feedback(rc)
+    return __train_fit(
+        rc, train_data, target_data, ps, st;
+        objective, solver, washout, return_states, kwargs...
+    )
 end
 
 @generated function __setweight_rt(p::NamedTuple{K}, W) where {K}

--- a/src/train.jl
+++ b/src/train.jl
@@ -197,6 +197,38 @@ function __train_ridge(
     return Matrix(solution.u')
 end
 
+function __shift_teacher(target_data::AbstractMatrix)
+    teacher = similar(target_data)
+    n_samples = size(target_data, 2)
+    teacher[:, 1] .= zero(eltype(target_data))
+    n_samples > 1 && (teacher[:, 2:n_samples] .= view(target_data, :, 1:(n_samples - 1)))
+    return teacher
+end
+
+function __train_collect_args(rc, train_data::AbstractMatrix, target_data)
+    __has_output_feedback(rc) || return train_data
+    size(target_data, 2) == size(train_data, 2) || throw(
+        DimensionMismatch(
+            "train data has $(size(train_data, 2)) samples, " *
+                "targets have $(size(target_data, 2))"
+        )
+    )
+    size(target_data, 1) == Int(__reservoir_cell(rc).feedback_dims) || throw(
+        DimensionMismatch(
+            "targets have $(size(target_data, 1)) rows, expected " *
+                "feedback_dims=$(__reservoir_cell(rc).feedback_dims)"
+        )
+    )
+    return (train_data, __shift_teacher(target_data))
+end
+
+function __train_collect_args(
+        rc, train_data::Tuple{<:AbstractMatrix, <:AbstractMatrix}, _
+    )
+    __require_output_feedback(rc)
+    return train_data
+end
+
 @doc raw"""
     train(rc, train_data, target_data, ps, st;
           objective=RidgeRegression(0.0), solver=nothing,
@@ -211,7 +243,11 @@ and returns new parameters and states (inputs `ps` / `st` are not mutated).
 
   - `rc`: model with a trainable readout (e.g. [`ESN`](@ref),
     [`ReservoirChain`](@ref)).
-  - `train_data`: inputs; columns are time steps.
+  - `train_data`: inputs; columns are time steps. For a reservoir with
+    output feedback, pass `(train_data, teacher_data)` to supply the
+    feedback \(\mathbf{y}\) aligned with each input column. If only the
+    input matrix is given, the teacher is `target_data` shifted one step,
+    with a zero column at the first time step.
   - `target_data`: targets aligned with `train_data`.
   - `ps`: model parameters.
   - `st`: model states.
@@ -237,7 +273,9 @@ function train(
         return_states::Bool = false,
         kwargs...
     )
-    raw_states, st_after = collectstates(rc, train_data, ps, st)
+    raw_states, st_after = collectstates(
+        rc, __train_collect_args(rc, train_data, target_data), ps, st
+    )
     states_wo,
         targets_wo = washout > 0 ? __apply_washout(raw_states, target_data, washout) :
         (raw_states, target_data)

--- a/test/Layers/esncell_tests.jl
+++ b/test/Layers/esncell_tests.jl
@@ -295,6 +295,49 @@ begin
         end
     end
 
+    @testset "ESNCell: output feedback" begin
+        @test_throws ArgumentError ESNCell(3 => 5; use_feedback = true)
+
+        cell = ESNCell(
+            3 => 3, identity;
+            use_bias = False(),
+            use_feedback = true,
+            feedback_dims = 3,
+            leak_coefficient = 1.0,
+            init_input = _W_I,
+            init_reservoir = _W_ZZ,
+            init_feedback = _W_I,
+            init_state = _Z32,
+        )
+        ps = initialparameters(MersenneTwister(0), cell)
+        @test size(ps.feedback_matrix) == (3, 3)
+        shown = sprint(show, cell)
+        @test occursin("use_feedback=true", shown)
+        @test occursin("feedback_dims=3", shown)
+        @test !occursin("use_feedback", sprint(show, ESNCell(3 => 5)))
+
+        u = Float32[1, 2, 3]
+        y_prev = Float32[4, 5, 6]
+        h0 = zeros(Float32, 3)
+        (h_tuple, _) = cell(((u, y_prev), (h0,)), ps, NamedTuple())
+        h_new, (hcarry,) = h_tuple
+        @test h_new ≈ u .+ y_prev
+        @test hcarry ≈ h_new
+
+        @test_throws ArgumentError cell((u, (h0,)), ps, NamedTuple())
+
+        cell_off = ESNCell(
+            3 => 3, identity;
+            use_bias = False(),
+            init_input = _W_I,
+            init_reservoir = _W_ZZ,
+            init_state = _Z32,
+        )
+        ps_off = initialparameters(MersenneTwister(0), cell_off)
+        @test !haskey(ps_off, :feedback_matrix)
+        @test_throws ArgumentError cell_off(((u, y_prev), (h0,)), ps_off, NamedTuple())
+    end
+
     @testset "ResESNCell: decoupled alpha/beta" begin
         cell = ResESNCell(
             3 => 3,

--- a/test/test_train_api.jl
+++ b/test/test_train_api.jl
@@ -115,3 +115,58 @@ end
     @test weights_default == weights_ls
     @test size(weights_default) == (n_outputs, n_features)
 end
+
+@testset "ESN output feedback: train, collectstates, predict" begin
+    rng = MersenneTwister(42)
+    eye32(m, n) = Matrix{Float32}(I, m, n)
+    init_I = (rng, m, n) -> eye32(m, n)
+    init_Z = (rng, m, n) -> zeros(Float32, m, n)
+    init_state0(rng, m, B) = B == 1 ? zeros(Float32, m) : zeros(Float32, m, B)
+
+    model = ESN(
+        3, 3, 3, identity;
+        use_feedback = true,
+        use_bias = false,
+        leak_coefficient = 1.0,
+        init_input = init_I,
+        init_reservoir = init_Z,
+        init_feedback = init_I,
+        init_state = init_state0,
+    )
+    ps, st = setup(rng, model)
+    @test size(ps.reservoir.feedback_matrix) == (3, 3)
+    ps = merge(ps, (readout = (; weight = eye32(3, 3)),))
+
+    data = Float32[1 0 0; 0 1 0; 0 0 1]
+    teacher_zero = zeros(Float32, 3, 3)
+    teacher_shift = Float32[0 1 0; 0 0 1; 0 0 0]
+
+    @test_throws ArgumentError collectstates(model, data, ps, st)
+    states_tf, _ = collectstates(model, (data, teacher_zero), ps, st)
+    @test states_tf ≈ data
+
+    Y_unlock, _ = predict(model, data, ps, st)
+    @test Y_unlock ≈ Float32[1 1 1; 0 1 1; 0 0 1]
+
+    Y_tf, _ = predict(model, (data, teacher_zero), ps, st)
+    @test Y_tf ≈ data
+
+    @test_throws ArgumentError predict(model, 3, ps, st; initialdata = data[:, 1])
+
+    targets = data
+    ps_auto, _ = train(
+        model, data, targets, ps, st;
+        objective = RidgeRegression(0.0),
+    )
+    ps_explicit, _ = train(
+        model, (data, teacher_shift), targets, ps, st;
+        objective = RidgeRegression(0.0),
+    )
+    @test ps_auto.readout.weight ≈ ps_explicit.readout.weight
+
+    plain = ESN(3, 12, 2)
+    ps_p, st_p = setup(MersenneTwister(42), plain)
+    @test_throws ArgumentError train(
+        plain, (data, teacher_zero), randn(Float32, 2, 3), ps_p, st_p
+    )
+end

--- a/test/test_train_ridge.jl
+++ b/test/test_train_ridge.jl
@@ -183,6 +183,24 @@ end
     end
 end
 
+@testset "__fit_readout(RidgeRegression): rank-deficient λ=0" begin
+    states = reshape(Float32.(1:24), 3, 8) ./ 10.0f0
+    y1 = states[1, :] .+ 2 .* states[2, :]
+    y2 = states[3, :] .- states[1, :]
+    targets = vcat(reshape(y1, 1, :), reshape(y2, 1, :))
+
+    weights = ReservoirComputing.__fit_readout(
+        RidgeRegression(Float32, 0), states, targets
+    )
+    weights_legacy = ReservoirComputing.__fit_readout(
+        RidgeRegression(Float32, 0), states, targets; solver = QRSolver()
+    )
+    @test size(weights) == (2, 3)
+    @test eltype(weights) === Float32
+    @test all(isfinite, weights)
+    @test weights ≈ weights_legacy rtol = 1.0e-5
+end
+
 @testset "__fit_readout(RidgeRegression): default solver is QRFactorization" begin
     rng = MersenneTwister(23)
     states, targets, _ = random_ridge_problem(rng, Float64, 5, 30, 2)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/ColPrac)
- [x] Any new documentation only uses public API

## Additional context

Optional `W_fb` on `ESNCell` / `ESN` (`use_feedback=true`). Default off.

Training teacher-forces from the target sequence, or from an explicit `(train_data, teacher_data)` pair. Driven `predict` then feeds the previous model output through `W_fb`. Autoregressive `predict(steps; initialdata)` is rejected for feedback models.

Closes #327