### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "LuxCore,StableRNGs"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,60 @@
+using ReservoirComputing, BenchmarkTools
+using LuxCore, StableRNGs, Random
+
+const SUITE = BenchmarkGroup()
+const rng = StableRNG(123)
+
+in_dims, res_dims, out_dims = 2, 100, 1
+n_steps = 100
+train_data = randn(rng, Float32, in_dims, n_steps)
+target_data = randn(rng, Float32, out_dims, n_steps)
+input_step = randn(rng, Float32, in_dims)
+
+# =============================================================================
+# Reservoir computer construction and inference
+# =============================================================================
+
+SUITE["esn"] = BenchmarkGroup()
+
+SUITE["esn"]["construct"] = @benchmarkable ESN(
+    $in_dims, $res_dims, $out_dims
+)
+SUITE["esn"]["construct_sparse"] = @benchmarkable ESN(
+    $in_dims, $res_dims, $out_dims; init_reservoir = sparse_init
+)
+SUITE["esn"]["construct_cycle"] = @benchmarkable ESN(
+    $in_dims, $res_dims, $out_dims; init_reservoir = cycle_jumps
+)
+
+esn = ESN(in_dims, res_dims, out_dims)
+ps, st = setup(rng, esn)
+
+SUITE["esn"]["setup"] = @benchmarkable setup($rng, $esn)
+SUITE["esn"]["step"] = @benchmarkable $esn($input_step, $ps, $st)
+
+# =============================================================================
+# Training (ridge-regression readout)
+# =============================================================================
+
+SUITE["train"] = BenchmarkGroup()
+
+ridge = RidgeRegression(2.0e-3)
+SUITE["train"]["train"] = @benchmarkable train(
+    $esn, $train_data, $target_data, $ps, $st; objective = $ridge
+)
+
+# =============================================================================
+# Reservoir inits
+# =============================================================================
+
+SUITE["init"] = BenchmarkGroup()
+
+SUITE["init"]["rand_sparse"] = @benchmarkable sparse_init(
+    $rng, Float32, $res_dims, $res_dims; sparsity = 0.1
+)
+SUITE["init"]["delay_line"] = @benchmarkable delay_line(
+    $rng, Float32, $res_dims, $res_dims
+)
+SUITE["init"]["chaotic"] = @benchmarkable chaotic_init(
+    $rng, Float32, $res_dims, $res_dims
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~28s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~28s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 Max)
Session: local transcript /home/crackauc/.local/share/devin/cli/summaries/history_ccb52064e6514b21.md