### PR TITLE
Update permutation_init doctests for Julia 1.13 randperm

### DIFF
--- a/src/inits/inits_reservoir.jl
+++ b/src/inits/inits_reservoir.jl
@@ -2240,11 +2240,11 @@ Default kwargs:
 ```jldoctest forcon
 julia> reservoir_matrix = permutation_init(5, 5)
 5×5 Matrix{Float32}:
- 0.0  0.0  0.0  0.0  0.1
- 0.0  0.1  0.0  0.0  0.0
- 0.1  0.0  0.0  0.0  0.0
  0.0  0.0  0.1  0.0  0.0
  0.0  0.0  0.0  0.1  0.0
+ 0.0  0.1  0.0  0.0  0.0
+ 0.1  0.0  0.0  0.0  0.0
+ 0.0  0.0  0.0  0.0  0.1
 ```
 
 Changing the weights magnitudes to a different unique value:
@@ -2252,11 +2252,11 @@ Changing the weights magnitudes to a different unique value:
 ```jldoctest forcon
 julia> reservoir_matrix = permutation_init(5, 5; weight=0.99)
 5×5 Matrix{Float32}:
- 0.0   0.0   0.0   0.0   0.99
- 0.0   0.99  0.0   0.0   0.0
- 0.99  0.0   0.0   0.0   0.0
  0.0   0.0   0.99  0.0   0.0
  0.0   0.0   0.0   0.99  0.0
+ 0.0   0.99  0.0   0.0   0.0
+ 0.99  0.0   0.0   0.0   0.0
+ 0.0   0.0   0.0   0.0   0.99
 ```
 
 Changing the weights signs with different sign patterns:
@@ -2264,11 +2264,11 @@ Changing the weights signs with different sign patterns:
 ```jldoctest forcon
 julia> reservoir_matrix = permutation_init(5, 5; signs = RandomSigns())
 5×5 Matrix{Float32}:
- 0.0  0.1   0.0  0.0   0.0
- 0.0  0.0  -0.1  0.0   0.0
- 0.1  0.0   0.0  0.0   0.0
- 0.0  0.0   0.0  0.0  -0.1
- 0.0  0.0   0.0  0.1   0.0
+  0.0  0.1  0.0   0.0  0.0
+ -0.1  0.0  0.0   0.0  0.0
+  0.0  0.0  0.0   0.0  0.1
+  0.0  0.0  0.0  -0.1  0.0
+  0.0  0.0  0.1   0.0  0.0
 ```
 
 Changing the weights to random numbers. Note that the length of the given array
@@ -2288,11 +2288,11 @@ Returning a sparse matrix:
 ```jldoctest forcon
 julia> reservoir_matrix = permutation_init(5, 5; return_sparse=true)
 5×5 SparseMatrixCSC{Float32, Int64} with 5 stored entries:
-  ⋅    ⋅    ⋅    ⋅   0.1
-  ⋅   0.1   ⋅    ⋅    ⋅
- 0.1   ⋅    ⋅    ⋅    ⋅
   ⋅    ⋅   0.1   ⋅    ⋅
   ⋅    ⋅    ⋅   0.1   ⋅
+  ⋅   0.1   ⋅    ⋅    ⋅
+ 0.1   ⋅    ⋅    ⋅    ⋅
+  ⋅    ⋅    ⋅    ⋅   0.1
 ```
 
 """


### PR DESCRIPTION
## Summary

The `GPU Documentation` job on master fails four `permutation_init` doctests in `src/inits/inits_reservoir.jl`. Julia 1.13 changed `randperm`'s implementation (`randperm(Xoshiro(1234), 5)` gives `[3,2,4,5,1]` on 1.12 vs `[4,3,1,2,5]` on 1.13), so the fixed-seed permutation matrices in the docstring no longer match.

This regenerates the four literal outputs on Julia 1.13. The evaluated values were confirmed byte-for-byte against the CI failure output (run 34675972399) and reproduced locally.

## Verification

Each doctest's new expected output matches what `permutation_init` evaluates to on Julia 1.13.0, e.g. `permutation_init(5, 5)` now shows the column-3/4/2/1/5 permutation CI produced. The `MersenneTwister(123)` example needs no update — it only asserts properties (`size` and sorted nonzero values), not the permutation order.

Note: the `Tests` failure on the same master run is a separate resolved-upstream issue (`OrdinaryDiffEqDefault` 2.6.2 now requires `OrdinaryDiffEqCore` ≥ 4.17.1, which provides `_is_identity_massmatrix`); it will pass on the next CI run and is not addressed here.

Generated with Devin CLI 3000.10.21 (model: SWE-2 Max), session: /home/crackauc/.local/share/devin/cli/summaries/history_4c9fddb81d834736.md